### PR TITLE
Removed unecessary functions

### DIFF
--- a/src/System/Console/Hawk/Config.hs
+++ b/src/System/Console/Hawk/Config.hs
@@ -71,9 +71,7 @@ defaultPrelude = unlines
 recompileConfigIfNeeded :: IO (String,String) -- ^ Maybe (FileName,ModuleName)
 recompileConfigIfNeeded = withLock $ do
     dir <- getConfigDir
-    dirExists <- doesDirectoryExist dir
-    unless dirExists $
-        createDirectoryIfMissing True dir
+    createDirectoryIfMissing True dir
     configFile <- getConfigFile
     configFileExists <- doesFileExist configFile
     unless configFileExists $


### PR DESCRIPTION
Refactored the code to just use `createDirectoryIfMissing` instead of binding `doesDirectoryExist` to `unless`. Achieves the same functionality in much less code.
