### PR TITLE
Fix build issue under ghc 7.10-rc3

### DIFF
--- a/src/Data/HaskellModule/Parse.hs
+++ b/src/Data/HaskellModule/Parse.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, PackageImports, RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, PackageImports, RecordWildCards #-}
 -- | In which a Haskell module is deconstructed into extensions and imports.
 module Data.HaskellModule.Parse (readModule) where
 


### PR DESCRIPTION
Add `FlexibleContexts` to Data.HaskellModule.Parse to remove error at line 48 (in derived type, in the constraint IsString [a]).

There is another build issue, but I believe it to be out of your control: dependencies fail as MonadCatchIO-transformers==0.3.1.0 has the upper bound `base<4.8`.

This appears to be the only change necessary for hawk to compile under ghc 7.10 (assuming you give cabal the --allow-newer flag.  Unfortunately, I'm still struggling to install everything necessary for the test suite still, so can't give feedback there yet, or run the suite to check everything is still working fine.