### PR TITLE
Cleanup warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ cabal-dev
 *.swp
 *.swo
 .virthualenv
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cabal-dev
 *.swp
 *.swo
 .virthualenv
+.vscode/

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,41 +1,41 @@
-import Control.Monad
-import Distribution.Simple
-import System.Environment
+import           Control.Monad
+import           Data.Maybe          (fromMaybe)
+import           Distribution.Simple
+import           System.Environment
 --import System.IO
 
 
 -- Surprisingly, if the user types "cabal install --enable-tests",
 -- `args` will *not* be ["install", "--enable-tests"]. Instead, cabal will
 -- run Setup.hs repeatedly with different arguments:
--- 
+--
 --     ["configure","--verbose=1","--builddir=dist/dist-sandbox-28d8356a","--ghc","--prefix=...",...]
 --     ["build","--verbose=1","--builddir=dist/dist-sandbox-28d8356a"]
 --     ["test","--builddir=dist/dist-sandbox-28d8356a"]
 --     ["install","--verbose=1","--builddir=dist/dist-sandbox-28d8356a"]
--- 
+--
 -- We need to manipulate `args` via `substitute` in order to preserve those
 -- extra arguments.
 substitute :: Eq a => [(a, [a])] -> [a] -> [a]
 substitute substitutions = (>>= go)
   where
-    go x = case lookup x substitutions of
-             Just xs -> xs
-             Nothing -> return x
+    go x = fromMaybe (return x)
+                     (lookup x substitutions)
 
 main = do
     args <- getArgs
-    
+
     --withFile "Setup.log" AppendMode $ \h -> do
     --  hPutStrLn h (show args)
-    
-    when ("test" `elem` args) $ do
+
+    when ("test" `elem` args) $
       -- unlike most packages, this one needs to be installed before it can be tested.
       defaultMainArgs (substitute [ ("test", ["install","--verbose=1"])
-                                  
+
                                   -- remove test-specific arguments
                                   , ("--log=$pkgid-$test-suite.log", [])
                                   , ("--machine-log=$pkgid.log", [])
                                   , ("--show-details=failures", [])
                                   ] args)
-    
+
     defaultMainArgs args

--- a/runtime/System/Console/Hawk/Representable.hs
+++ b/runtime/System/Console/Hawk/Representable.hs
@@ -24,14 +24,14 @@ module System.Console.Hawk.Representable (
 
 ) where
 
-import Prelude
-import Data.ByteString.Lazy.Char8 (ByteString)
+import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as C8 hiding (hPutStrLn)
-import qualified Data.List as L
-import Data.Set (Set)
-import qualified Data.Set as S
-import Data.Map (Map)
-import qualified Data.Map as M
+import qualified Data.List                  as L
+import           Data.Map                   (Map)
+import qualified Data.Map                   as M
+import           Data.Set                   (Set)
+import qualified Data.Set                   as S
+import           Prelude
 
 
 -- | A type that instantiate ListAsRow is a type that has a representation
@@ -66,7 +66,7 @@ instance ListAsRow Char where
     listRepr' _ = C8.pack
 
 instance ListAsRow ByteString where
-    listRepr' d = C8.intercalate d
+    listRepr' = C8.intercalate
 
 instance (Row a, Row b) => ListAsRow (Map a b) where
     listRepr' d = listRepr' d . L.map (listRepr' d . M.toList)
@@ -257,7 +257,7 @@ instance ListAsRows Int
 instance ListAsRows Integer
 instance (Row a) => ListAsRows (Maybe a)
 instance ListAsRows ()
-instance (ListAsRow a,ListAsRows a) => ListAsRows [a]
+instance (ListAsRow a) => ListAsRows [a]
 instance (Row a,Row b) => ListAsRows (a,b)
 instance (Row a,Row b,Row c) => ListAsRows (a,b,c)
 instance (Row a,Row b,Row c,Row d) => ListAsRows (a,b,c,d)
@@ -274,7 +274,7 @@ instance (Row a,Row b,Row c,Row d,Row e,Row f,Row g,Row h,Row i,Row l)
 instance ListAsRows Char where
     listRepr _ = (:[]) . C8.pack
 
-instance (ListAsRow a,ListAsRows a) => ListAsRows (Set a) where
+instance (ListAsRow a) => ListAsRows (Set a) where
     listRepr d = listRepr d . L.map S.toList
 
 instance (Row a,Row b) => ListAsRows (Map a b) where

--- a/runtime/System/Console/Hawk/Runtime.hs
+++ b/runtime/System/Console/Hawk/Runtime.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE ExistentialQuantification, OverloadedStrings, RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RankNTypes                #-}
 -- | Applying the user expression as directed by the HawkRuntime.
 --   The API may change at any time.
 module System.Console.Hawk.Runtime
@@ -6,16 +8,15 @@ module System.Console.Hawk.Runtime
   , processTable
   ) where
 
-import Control.Applicative
-import Control.Exception
-import Data.ByteString.Lazy.Char8 as B
-import Data.ByteString.Lazy.Search as Search
-import GHC.IO.Exception
-import System.IO
+import           Control.Exception
+import           Data.ByteString.Lazy.Char8        as B
+import           Data.ByteString.Lazy.Search       as Search
+import           GHC.IO.Exception
+import           System.IO
 
-import System.Console.Hawk.Args.Spec
-import System.Console.Hawk.Representable
-import System.Console.Hawk.Runtime.Base
+import           System.Console.Hawk.Args.Spec
+import           System.Console.Hawk.Representable
+import           System.Console.Hawk.Runtime.Base
 
 
 data SomeRows = forall a. Rows a => SomeRows a
@@ -81,16 +82,16 @@ outputRows (OutputSpec _ spec) x = ignoringBrokenPipe $ do
   where
     join' = join (B.fromStrict $ recordDelimiter spec)
     toRows = repr (B.fromStrict $ fieldDelimiter spec)
-    
+
     join :: B.ByteString -> [B.ByteString] -> B.ByteString
     join "\n" = B.unlines
     join sep  = B.intercalate sep
 
 -- Don't fret if stdout is closed early, that is the way of shell pipelines.
 ignoringBrokenPipe :: IO () -> IO ()
-ignoringBrokenPipe = handleJust isBrokenPipe $ \_ -> do
+ignoringBrokenPipe = handleJust isBrokenPipe $ \_ ->
     -- ignore the broken pipe
     return ()
   where
     isBrokenPipe e | ioe_type e == ResourceVanished = Just e
-    isBrokenPipe _ | otherwise                      = Nothing
+    isBrokenPipe _                                  = Nothing

--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -1,22 +1,23 @@
-{-# LANGUAGE PackageImports, RankNTypes #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE RankNTypes     #-}
 -- | A typeclass- and monad-based interface for GetOpt,
 --   designed to look as if the options had more precise types than String.
 module Control.Monad.Trans.OptionParser where
 
-import Control.Applicative
-import Control.Monad
-import "mtl" Control.Monad.Identity
-import "mtl" Control.Monad.Trans
-import Control.Monad.Trans.State
-import Data.List
-import Data.Maybe
-import qualified System.Console.GetOpt as GetOpt
-import Text.Printf
+import           Control.Applicative           ((<$>))
+import           Control.Monad
+import           "mtl" Control.Monad.Identity
+import           "mtl" Control.Monad.Trans
+import           Control.Monad.Trans.State
+import           Data.List
+import           Data.Maybe
+import qualified System.Console.GetOpt         as GetOpt
+import           Text.Printf
 
-import Control.Monad.Trans.Uncertain
+import           Control.Monad.Trans.Uncertain
 
 -- $setup
--- 
+--
 -- >>> :{
 -- let testH tp = do { putStrLn "Usage: more [option]... <song.mp3>"
 --                   ; putStr $ optionsHelpWith head
@@ -26,7 +27,7 @@ import Control.Monad.Trans.Uncertain
 --                                              ["cowbell","guitar","saxophone"]
 --                   }
 -- :}
--- 
+--
 -- >>> let testP args tp p = runUncertain $ runOptionParserWith head id (const [""]) tp ["cowbell","guitar","saxophone"] p args
 
 
@@ -41,7 +42,7 @@ class Eq a => Option a where
 -- | The type of the argument set by the option. Since Haskell doesn't support
 --   dependent types, this is just a string description of the type, plus extra
 --   support for boolean flags and optional arguments.
--- 
+--
 -- To maintain the illusion of precise types, please use combining functions
 -- such as `nullable int` instead.
 data OptionType
@@ -85,7 +86,7 @@ instance MonadIO m => MonadIO (OptionParserT o m) where
 mapOptionParserT :: (forall a. m a -> m' a)
                  -> OptionParserT o m b -> OptionParserT o m' b
 mapOptionParserT f = OptionParserT
-                   . (mapStateT $ mapStateT $ mapUncertainT f)
+                   . mapStateT (mapStateT $ mapUncertainT f)
                    . unOptionParserT
 
 liftUncertain :: (Monad m) => UncertainT m a -> OptionParserT o m a
@@ -118,21 +119,21 @@ optionsHelp :: Option o => [o] -> String
 optionsHelp = optionsHelpWith shortName longName helpMsg optionType
 
 -- | A version of `optionsHelp` which doesn't use the Option typeclass.
--- 
+--
 -- >>> :{
 -- let { tp "cowbell"   = flag
 --     ; tp "guitar"    = string
 --     ; tp "saxophone" = nullable int
 --     }
 -- :}
--- 
+--
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
 -- Options:
 --   -c       --cowbell          adds more cowbell.
 --   -g str   --guitar=str       adds more guitar.
 --   -s[int]  --saxophone[=int]  adds more saxophone.
--- 
+--
 optionsHelpWith :: (o -> Char)
                 -> (o -> String)
                 -> (o -> [String])
@@ -156,7 +157,7 @@ runOptionParserT :: (Option o, Monad m)
 runOptionParserT = runOptionParserWith shortName longName helpMsg optionType
 
 -- | A version of `runOptionParserT` which doesn't use the Option typeclass.
--- 
+--
 -- >>> :{
 -- testP ["--cowbell","-s"] (const flag) $ do
 --   { c <- consumeLast "cowbell"   False consumeFlag
@@ -166,7 +167,7 @@ runOptionParserT = runOptionParserWith shortName longName helpMsg optionType
 --   }
 -- :}
 -- (True,False,True)
-runOptionParserWith :: (Eq o, Monad m)
+runOptionParserWith :: (Monad m)
                     => (o -> Char)
                     -> (o -> String)
                     -> (o -> [String])
@@ -195,7 +196,7 @@ runOptionParserWith shortName' longName' helpMsg' optionType'
 
 
 -- | Try to parse a setting of a particular type.
--- 
+--
 -- The input will never be Nothing unless the optionType is nullable, and even
 -- then consumeNullable will get rid of it for you. Yet we still need the type
 -- of the input to be `Maybe String` in order for consumeNullable itself to be
@@ -204,7 +205,7 @@ type OptionConsumer m a = Maybe String -> UncertainT m a
 
 
 -- | Specifies that the option cannot be assigned a value.
--- 
+--
 -- >>> let tp = const flag
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -216,13 +217,13 @@ flag :: OptionType
 flag = Flag
 
 -- | True if the given flag appears.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consumeCowbell = consumeLast "cowbell" False consumeFlag :: OptionParser String Bool
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- True
--- 
+--
 -- >>> testP ["--saxophone"] tp consumeCowbell
 -- False
 consumeFlag :: Monad m => OptionConsumer m Bool
@@ -230,7 +231,7 @@ consumeFlag _ = return True
 
 
 -- | Specifies that the option must be assigned a String value.
--- 
+--
 -- >>> let tp = const string
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -242,19 +243,19 @@ string :: OptionType
 string = Setting "str"
 
 -- | The value assigned to the option, interpreted as a string.
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" consumeString :: OptionParser String String
--- 
+--
 -- >>> testP ["--cowbell", "extra"] tp consumeCowbell
 -- "extra"
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- "s"
--- 
+--
 -- >>> testP [] tp consumeCowbell
 -- "<none>"
--- 
+--
 -- >>> testP ["-c"] tp consumeCowbell
 -- error: option `-c' requires an argument str
 -- *** Exception: ExitFailure 1
@@ -264,7 +265,7 @@ consumeString Nothing = error "please use consumeNullable to consume nullable op
 
 
 -- | Specifies that the value of the option may be omitted.
--- 
+--
 -- >>> let tp = const (nullable string)
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -279,19 +280,19 @@ nullable Flag = error "nullable flag doesn't make sense"
 
 -- | The value assigned to an option, or a default value if no value was
 --   assigned. Must be used to consume `nullable` options.
--- 
+--
 -- >>> let tp = const (nullable string)
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" $ consumeNullable "<default>" consumeString :: OptionParser String String
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- "s"
--- 
+--
 -- >>> testP ["-c", "-s"] tp consumeCowbell
 -- "<default>"
--- 
+--
 -- >>> testP ["-s"] tp consumeCowbell
 -- "<none>"
--- 
+--
 -- >>> testP ["-c"] tp $ consumeLast "cowbell" "<none>" consumeString
 -- *** Exception: please use consumeNullable to consume nullable options
 consumeNullable :: Monad m => a -> OptionConsumer m a -> OptionConsumer m a
@@ -300,14 +301,14 @@ consumeNullable _ consume o = consume o
 
 
 -- | A helper for defining custom options types.
--- 
+--
 -- >>> :{
 -- let { tp "cowbell"   = readable "amount"
 --     ; tp "guitar"    = readable "file"
 --     ; tp "saxophone" = readable "weight"
 --     }
 -- :}
--- 
+--
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
 -- Options:
@@ -318,13 +319,13 @@ readable :: String -> OptionType
 readable = Setting
 
 -- | The value assigned to the option, interpreted by `read`.
--- 
+--
 -- >>> let tp = const (readable "unit")
 -- >>> let consumeCowbell = consumeLast "cowbell" () consumeReadable :: OptionParser String ()
--- 
+--
 -- >>> testP ["--cowbell=()"] tp consumeCowbell >>= print
 -- ()
--- 
+--
 -- >>> testP ["--cowbell=foo"] tp consumeCowbell >>= print
 -- error: "foo" is not a valid value for this option.
 -- *** Exception: ExitFailure 1
@@ -337,19 +338,19 @@ consumeReadable o = do
 
 
 -- | Users are encouraged to create custom option types, like this.
--- 
+--
 -- (see the source)
 int :: OptionType
 int = readable "int"
 
 -- | The value assigned to the option, interpreted as an int.
--- 
+--
 -- This is a good example of how to consume custom option types.
 -- (see the source)
--- 
+--
 -- >>> let tp = const int
 -- >>> let consumeCowbell = consumeLast "cowbell" (-1) consumeInt :: OptionParser String Int
--- 
+--
 -- >>> testP ["--cowbell=42"] tp consumeCowbell
 -- 42
 consumeInt :: Monad m => OptionConsumer m Int
@@ -386,17 +387,17 @@ filePath = Setting "path"
 -- *** Exception: ExitFailure 1
 consumeFilePath :: MonadIO m
                 => (FilePath -> UncertainT m FilePath) -> OptionConsumer m String
-consumeFilePath check input = consumeString input >>= check >>= return
+consumeFilePath check input = consumeString input >>= check
 
 
 -- | All the occurences of a given option.
--- 
+--
 -- It is an error to consume the same value twice (we currently return an
 -- empty list).
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeAll "cowbell" consumeString :: OptionParser String [String]
--- 
+--
 -- >>> :{
 -- testP ["--cowbell=foo", "--cowbell", "bar"] tp $ do
 --   { xs <- consumeCowbell
@@ -413,13 +414,13 @@ consumeAll o consume = OptionParserT $ do
 
 -- | The last occurence of a given option, or a default value if the option
 --   isn't specified.
--- 
+--
 -- It is an error to consume the same value twice (we currently return the
 -- default value).
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" consumeString :: OptionParser String String
--- 
+--
 -- >>> :{
 -- testP ["--cowbell=foo", "--cowbell", "bar"] tp $ do
 --   { xs <- consumeCowbell
@@ -436,25 +437,25 @@ consumeLast o defaultValue consume = do
 
 
 -- | For use with mutually-exclusive flags.
-consumeExclusive :: (Option o, Functor m, Monad m)
+consumeExclusive :: (Option o, Monad m)
                  => [(o, a)] -> a -> OptionParserT o m a
 consumeExclusive = consumeExclusiveWith longName
 
 -- | A version of `consumeExclusive` which doesn't use the Option typeclass.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExclusiveWith id [("cowbell",0),("guitar",1),("saxophone",2)] (-1) :: OptionParser String Int
--- 
+--
 -- >>> testP ["-s"] tp consume
 -- 2
--- 
+--
 -- >>> testP [] tp consume
 -- -1
--- 
+--
 -- >>> testP ["-cs"] tp consume
 -- error: cowbell and saxophone are incompatible
 -- *** Exception: ExitFailure 1
-consumeExclusiveWith :: (Eq o, Functor m, Monad m)
+consumeExclusiveWith :: (Eq o, Monad m)
                      => (o -> String)
                      -> [(o, a)] -> a -> OptionParserT o m a
 consumeExclusiveWith longName' assoc defaultValue = do
@@ -471,19 +472,19 @@ consumeExclusiveWith longName' assoc defaultValue = do
 
 
 -- | The next non-option argument.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExtra consumeString :: OptionParser String (Maybe String)
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp consume
 -- Just "song.mp3"
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume)
 -- Just "jazz.mp3"
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume >> consume)
 -- Nothing
-consumeExtra :: (Functor m, Monad m)
+consumeExtra :: (Monad m)
              => OptionConsumer m a -> OptionParserT o m (Maybe a)
 consumeExtra consume = OptionParserT $ do
     extra_options <- lift get
@@ -494,21 +495,21 @@ consumeExtra consume = OptionParserT $ do
         fmap Just $ lift . lift $ consume $ Just x
 
 -- | All remaining non-option arguments.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExtras consumeString :: OptionParser String [String]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp consume
 -- ["song.mp3","jazz.mp3"]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consumeExtra consumeString >> consume)
 -- ["jazz.mp3"]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume)
 -- []
-consumeExtras :: (Functor m, Monad m)
+consumeExtras :: (Monad m)
               => OptionConsumer m a -> OptionParserT o m [a]
-consumeExtras consume = fmap reverse $ go []
+consumeExtras consume = reverse <$> go []
   where
     go xs = do
         r <- consumeExtra consume

--- a/src/Control/Monad/Trans/State/Persistent.hs
+++ b/src/Control/Monad/Trans/State/Persistent.hs
@@ -1,16 +1,17 @@
-{-# LANGUAGE PackageImports, ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | In which the state of a State monad is persisted to disk.
 module Control.Monad.Trans.State.Persistent where
 
-import Control.Applicative
-import Control.Monad
-import Control.Monad.IO.Class
-import "mtl" Control.Monad.Trans
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.State
-import Data.Functor.Identity
-import System.Directory
-import System.IO
+import           Control.Applicative
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           "mtl" Control.Monad.Trans
+import           Control.Monad.Trans.Maybe
+import           Control.Monad.Trans.State
+import           Data.Functor.Identity
+import           System.Directory
+import           System.IO
 
 -- $setup
 -- >>> import System.FilePath
@@ -19,60 +20,60 @@ import System.IO
 
 
 -- | Read and write the cache to a file. Not atomic.
--- 
+--
 -- >>> :{
 -- do { exists <- doesFileExist f
 --    ; when exists $ removeFile f
 --    }
 -- :}
--- 
+--
 -- >>> withPersistentState f 0 $ modify (+1) >> get
 -- 1
 -- >>> withPersistentState f 0 $ modify (+1) >> get
 -- 2
--- 
+--
 -- >>> removeFile f
 withPersistentState :: forall s a. (Read s, Show s, Eq s)
                     => FilePath -> s -> State s a -> IO a
-withPersistentState f default_s sx = do
+withPersistentState f default_s sx =
     withPersistentStateT f default_s sTx
   where
     sTx :: StateT s IO a
     sTx = mapStateT (return . runIdentity) sx
 
 -- | A monad-transformer version of `withPersistentState`.
--- 
+--
 -- >>> :{
 -- do { exists <- doesFileExist f
 --    ; when exists $ removeFile f
 --    }
 -- :}
--- 
+--
 -- >>> withPersistentStateT f 0 $ lift (putStrLn "hello") >> modify (+1) >> get
 -- hello
 -- 1
 -- >>> withPersistentStateT f 0 $ lift (putStrLn "hello") >> modify (+1) >> get
 -- hello
 -- 2
--- 
--- 
+--
+--
 -- If the contents of the file has been corrupted, revert to the default value.
--- 
+--
 -- >>> withPersistentStateT f "." $ lift (putStrLn "hello") >> modify (++".") >> get
 -- hello
 -- ".."
 -- >>> withPersistentStateT f "." $ lift (putStrLn "hello") >> modify (++".") >> get
 -- hello
 -- "..."
--- 
--- 
+--
+--
 -- >>> removeFile f
-withPersistentStateT :: forall m s a. (Functor m, MonadIO m, Read s, Show s, Eq s)
+withPersistentStateT :: forall m s a. (MonadIO m, Read s, Show s, Eq s)
                      => FilePath -> s -> StateT s m a -> m a
 withPersistentStateT f default_s sx = do
     Just s <- runMaybeT (get_s <|> get_default_s)
     (x, s') <- runStateT sx s
-    when (s' /= s) $ do
+    when (s' /= s) $
       liftIO $ writeFile f $ show s'
     return x
   where
@@ -80,7 +81,7 @@ withPersistentStateT f default_s sx = do
     get_s = do
         exists <- liftIO $ doesFileExist f
         guard exists
-        
+
         -- close the file even if the parsing fails
         Just s <- liftIO $ withFile f ReadMode $ \h -> do
           file_contents <- hGetContents h
@@ -88,14 +89,14 @@ withPersistentStateT f default_s sx = do
             [(s, "")] -> return (Just s)
             _         -> return Nothing
         return s
-    
+
     get_default_s :: MaybeT m s
     get_default_s = return default_s
 
 
 -- | Combine consecutive StateT transformers into a single StateT, so the state
 --   can be persisted to a single file.
--- 
+--
 -- >>> let sx = modify (+10)       :: StateT Int (State Int) ()
 -- >>> let tx = lift $ modify (*2) :: StateT Int (State Int) ()
 -- >>> execState (withCombinedState $ sx >> tx) (1, 2)

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -129,17 +129,17 @@ withAssocCache body = evalStateT (body assocCache) []
 -- [3,3,3,3,7,7]
 finiteCache :: Monad m => Int -> Cache m k a -> Cache (StateT Int m) k a
 finiteCache n c = Cache
-    { readCache      = lift . readCache      c
+    { readCache      =                  lift . readCache     c
     , writeCache     = \k v -> do
         alreadyFull <- isFull
         if alreadyFull
           then return False
           else do
-            r <- lift $ writeCache c k v
+            r <- lift $                 writeCache           c k v
             when r incr
             return r
-    , clearCache     =         put 0 >> lift (clearCache     c)
-    , clearFromCache = \k   -> decr  >> lift (clearFromCache c k)
+    , clearCache     =         put 0 >> lift (clearCache     c    )
+    , clearFromCache = \k   -> decr  >> lift (clearFromCache c k  )
     }
   where
     isFull = fmap (== n) get

--- a/src/Data/HaskellModule.hs
+++ b/src/Data/HaskellModule.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 -- | An opaque representation of a Haskell module.
--- 
+--
 -- The few parts which can be modified are easier to modify than using raw
 -- bytes or a raw HaskellSource.
 module Data.HaskellModule
@@ -10,20 +10,20 @@ module Data.HaskellModule
   , compileModule, compileModuleWithArgs
   ) where
 
-import Control.Monad.Trans.Class
-import qualified Data.ByteString.Char8 as B
+import           Control.Monad.Trans.Class
+import qualified Data.ByteString.Char8         as B
 
-import Data.HaskellSource
-import Control.Monad.Trans.Uncertain
+import           Control.Monad.Trans.Uncertain
+import           Data.HaskellSource
 
 -- Most of the API is re-exported from those submodules
-import Data.HaskellModule.Base
-import Data.HaskellModule.Parse
+import           Data.HaskellModule.Base
+import           Data.HaskellModule.Parse
 
 
 -- |
 -- >>> B.putStr $ showModule "orig.hs" $ emptyModule
--- 
+--
 -- >>> B.putStr $ showModule "orig.hs" $ addExtension "OverloadedStrings" $ addImport ("Data.ByteString.Char8", Just "B") $ addExtension "RecordWildCards" $ addImport ("Prelude", Nothing) $ emptyModule
 -- {-# LANGUAGE OverloadedStrings #-}
 -- {-# LANGUAGE RecordWildCards #-}
@@ -32,7 +32,7 @@ import Data.HaskellModule.Parse
 showModule :: FilePath -- ^ the original's filename,
                        --   used for fixing up line numbers
            -> HaskellModule -> B.ByteString
-showModule orig (HaskellModule {..}) = showSource orig fullSource
+showModule orig HaskellModule {..} = showSource orig fullSource
   where
     fullSource = concat [ pragmaSource
                         , moduleSource

--- a/src/Language/Haskell/Exts/Location.hs
+++ b/src/Language/Haskell/Exts/Location.hs
@@ -1,11 +1,11 @@
 -- | Easier access to haskell-src-exts's SrcLoc values.
 module Language.Haskell.Exts.Location where
 
-import Control.Monad
-import Control.Monad.Trans.Writer
-import Language.Haskell.Exts.Syntax
+import           Control.Monad
+import           Control.Monad.Trans.Writer
+import           Language.Haskell.Exts.Syntax
 
-import Data.Monoid.Ord
+import           Data.Monoid.Ord
 
 
 -- | Many haskell-src-exts datastructures contain a SrcLoc,
@@ -56,6 +56,12 @@ instance Location Decl where
   location (SpecInlineSig    loc _ _ _ _)       = Just loc
   location (InstSig          loc _ _ _ _)       = Just loc
   location (AnnPragma        loc _)             = Just loc
+  location (ClosedTypeFamDecl loc _ _ _ _)      = Just loc
+  location (PatSynSig         loc _ _ _ _ _)    = Just loc
+  location (PatSyn            loc _ _ _)        = Just loc
+  location (MinimalPragma     loc _)            = Just loc
+  location (RoleAnnotDecl     loc _ _)          = Just loc
+
 
 instance Location Match where
   location (Match loc _ _ _ _ _) = Just loc
@@ -69,7 +75,7 @@ instance Location a => Location [a] where
 
 
 -- | A value obtained from a particular location in the source code.
--- 
+--
 -- The location only indicates the beginning of a range, because that's what
 -- haskell-src-exts provides.
 type Located a = Writer (MinPriority SrcLoc) a

--- a/src/System/Console/Hawk/Args/Option.hs
+++ b/src/System/Console/Hawk/Args/Option.hs
@@ -2,11 +2,11 @@
 -- | The string-typed version of Hawk's command-line arguments.
 module System.Console.Hawk.Args.Option where
 
-import Data.ByteString (ByteString)
-import Data.ByteString.Char8 (pack)
-import Text.Printf
+import           Data.ByteString                  (ByteString)
+import           Data.ByteString.Char8            (pack)
+import           Text.Printf
 
-import Control.Monad.Trans.OptionParser
+import           Control.Monad.Trans.OptionParser
 
 
 data HawkOption
@@ -30,16 +30,16 @@ delimiter :: OptionType
 delimiter = nullable (Setting "delim")
 
 -- | Interpret escape sequences, but don't worry if they're invalid.
--- 
+--
 -- >>> parseDelimiter ","
 -- ","
--- 
+--
 -- >>> parseDelimiter "\\n"
 -- "\n"
--- 
+--
 -- >>> parseDelimiter "\\t"
 -- "\t"
--- 
+--
 -- >>> parseDelimiter "\\"
 -- "\\"
 parseDelimiter :: String -> ByteString
@@ -48,7 +48,7 @@ parseDelimiter s = pack $ case reads (printf "\"%s\"" s) of
     _          -> s
 
 -- | Almost like a string, except escape sequences are interpreted.
-consumeDelimiter :: (Functor m, Monad m) => OptionConsumer m ByteString
+consumeDelimiter :: (Monad m) => OptionConsumer m ByteString
 consumeDelimiter = fmap parseDelimiter . consumeNullable "" consumeString
 
 instance Option HawkOption where
@@ -61,7 +61,7 @@ instance Option HawkOption where
   shortName Version               = 'v'
   shortName Help                  = 'h'
   shortName ContextDirectory      = 'c'
-  
+
   longName Apply                 = "apply"
   longName Map                   = "map"
   longName FieldDelimiter        = "field-delimiter"
@@ -71,7 +71,7 @@ instance Option HawkOption where
   longName Version               = "version"
   longName Help                  = "help"
   longName ContextDirectory      = "context-directory"
-  
+
   helpMsg Apply                      = ["apply <expr> to the entire table"]
   helpMsg Map                        = ["apply <expr> to each row"]
   helpMsg FieldDelimiter             = ["default whitespace"]
@@ -82,7 +82,7 @@ instance Option HawkOption where
   helpMsg Help                       = ["this help"]
   helpMsg ContextDirectory           = ["<ctx-dir> directory, default is"
                                        ,"'~/.hawk'"]
-  
+
   optionType Apply                 = flag
   optionType Map                   = flag
   optionType FieldDelimiter        = delimiter

--- a/src/System/Console/Hawk/Context/Dir.hs
+++ b/src/System/Console/Hawk/Context/Dir.hs
@@ -6,15 +6,15 @@ module System.Console.Hawk.Context.Dir
   , checkContextDir
   ) where
 
-import Control.Monad
-import "mtl" Control.Monad.Trans
-import System.Directory
-import System.FilePath
+import           Control.Monad
+import           "mtl" Control.Monad.Trans
+import           System.Directory
+import           System.FilePath
 
-import Control.Monad.Trans.Uncertain
-import System.Console.Hawk.Context.Paths
-import System.Console.Hawk.UserPrelude.Defaults
-import System.Directory.Extra
+import           Control.Monad.Trans.Uncertain
+import           System.Console.Hawk.Context.Paths
+import           System.Console.Hawk.UserPrelude.Defaults
+import           System.Directory.Extra
 
 
 -- | Create a default context
@@ -36,7 +36,7 @@ findContext startDir =
   where
     mkHawkPath = (</> ".hawk")
     possibleContextDirs = map mkHawkPath (ancestors startDir)
-    
+
     validDirOrNothing dir = do
       dirExists <- doesDirectoryExist dir
       if dirExists
@@ -80,10 +80,10 @@ checkContextDir dir = do
     if dirExists
       then do
         permissions <- liftIO $ getPermissions dir
-        when (not $ writable permissions) $ fail $ concat [
+        unless (writable permissions) $ fail $ concat [
            "cannot use '",dir,"' as context directory because it is not "
           ,"writable"]
-        when (not $ searchable permissions) $ fail $ concat [
+        unless (searchable permissions) $ fail $ concat [
            "cannot use '",dir,"' as context directory because it is not "
           ,"searchable"]
         return False
@@ -92,10 +92,10 @@ checkContextDir dir = do
         -- and searchable
         let parent = case takeDirectory dir of {"" -> ".";p -> p}
         permissions <- liftIO $ getPermissions parent
-        when (not $ writable permissions) $ fail $ concat[
+        unless (writable permissions) $ fail $ concat[
            "cannot create context directory '",dir,"' because the parent "
           ," directory is not writable (",show permissions,")"]
-        when (not $ searchable permissions) $ fail $ concat[
+        unless (searchable permissions) $ fail $ concat[
            "cannot create context directory '",dir,"' because the parent "
           ," directory is not searchable (",show permissions,")"]
         warn $ concat ["directory '",dir,"' doesn't exist, creating a "

--- a/src/System/Console/Hawk/Interpreter.hs
+++ b/src/System/Console/Hawk/Interpreter.hs
@@ -4,15 +4,15 @@ module System.Console.Hawk.Interpreter
   , runHawkInterpreter
   ) where
 
-import Control.Monad
-import Data.List
-import Language.Haskell.Interpreter
+import           Control.Monad
+import           Data.List
+import           Language.Haskell.Interpreter
 
-import Control.Monad.Trans.Uncertain
-import qualified System.Console.Hawk.Context as Context
-import qualified System.Console.Hawk.Sandbox as Sandbox
-import System.Console.Hawk.UserPrelude.Defaults
-import System.Console.Hawk.Lock
+import           Control.Monad.Trans.Uncertain
+import qualified System.Console.Hawk.Context              as Context
+import           System.Console.Hawk.Lock
+import qualified System.Console.Hawk.Sandbox              as Sandbox
+import           System.Console.Hawk.UserPrelude.Defaults
 
 -- $setup
 -- >>> import System.Console.Hawk.Args.Spec
@@ -24,17 +24,17 @@ applyContext :: FilePath -- ^ context directory
              -> InterpreterT IO ()
 applyContext contextDir = do
     context <- lift $ runUncertainIO $ Context.getContext contextDir
-    
+
     let extensions = map read $ Context.extensions context
     let preludeFile = Context.canonicalPreludePath (Context.contextPaths context)
     let preludeModule = Context.moduleName context
     let userModules = Context.modules context
-    
+
     set [languageExtensions := extensions]
-    
+
     -- load the prelude file
     loadModules [preludeFile]
-    
+
     -- load the prelude module plus representable etc.
     setImportsQ $ (preludeModule,Nothing):defaultModules
                                        ++ userModules
@@ -44,7 +44,7 @@ errorString :: InterpreterError -> String
 errorString (WontCompile es) = intercalate "\n" (header : map indent es)
   where
     header = "Won't compile:"
-    indent (GhcError e) = ('\t':e)
+    indent (GhcError e) = '\t' : e
 errorString e = show e
 
 wrapErrorsM :: Monad m => m (Either InterpreterError a) -> UncertainT m a

--- a/src/System/Console/Hawk/Lock.hs
+++ b/src/System/Console/Hawk/Lock.hs
@@ -20,16 +20,16 @@ module System.Console.Hawk.Lock
     , withTestLock
     ) where
 
-import Control.Concurrent ( threadDelay )
-import Control.Exception
-import Control.Monad ( when, guard )
-import Data.List ( elemIndex )
-import GHC.IO.Exception
-import GHC.IO.Handle ( Handle, hGetContents, hClose )
-import Network.BSD ( getProtocolNumber ) -- still cross-platform, don't let the name fool you
-import Network ( PortID (..), connectTo )
-import Network.Socket
-import Text.Printf
+import           Control.Concurrent (threadDelay)
+import           Control.Exception
+import           Control.Monad      (guard, when)
+import           Data.List          (elemIndex)
+import           GHC.IO.Exception
+import           GHC.IO.Handle      (Handle, hClose, hGetContents)
+import           Network            (PortID (..), connectTo)
+import           Network.BSD        (getProtocolNumber)
+import           Network.Socket
+import           Text.Printf
 
 
 -- use a socket number as a lock indicator.
@@ -52,19 +52,19 @@ type Lock = Socket
 lock :: Bool -> IO Lock
 lock testing = catchJust isADDRINUSE openSocket $ \() -> do
     -- open failed, the lock must be in use.
-    
+
     when testing $ putStrLn "** LOCKED **"
-    
+
     -- used to test an interleaving in which the socket is closed here,
     -- between openSocket and waitForException.
     when testing $ threadDelay 20000
-    
+
     -- wait for the other instance to signal that it is done with the lock.
     catchJust isDisconnected waitForException $ \_ -> do
       -- we were disconnected, the server must have released the lock!
-      
+
       when testing $ printf "** UNLOCKED **\n"
-      
+
       -- try again.
       lock testing
 
@@ -114,7 +114,7 @@ listenOn port = do
     proto <- getProtocolNumber "tcp"
     bracketOnError
         (socket AF_INET Stream proto)
-        (sClose)
+        sClose
         (\sock -> do
             -- unlike the original listenOn, we do NOT set ReuseAddr.
             -- this way the call will fail if another instance holds the lock.

--- a/src/System/Console/Hawk/Runtime/HaskellExpr.hs
+++ b/src/System/Console/Hawk/Runtime/HaskellExpr.hs
@@ -2,15 +2,14 @@
 --   System.Console.Hawk.Runtime
 module System.Console.Hawk.Runtime.HaskellExpr where
 
-import qualified Data.ByteString.Lazy.Char8 as B
+import qualified Data.ByteString.Lazy.Char8       as B
 
-import Data.HaskellExpr
-import System.Console.Hawk.Representable
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.Base
+import           Data.HaskellExpr
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.Base
 
 
-eSomeRows :: Rows a => HaskellExpr (a -> SomeRows)
+eSomeRows :: HaskellExpr (a -> SomeRows)
 eSomeRows = qualified "System.Console.Hawk.Runtime" "SomeRows"
 
 eProcessTable :: HaskellExpr (HawkRuntime -> ([[B.ByteString]] -> SomeRows) -> HawkIO ())

--- a/src/System/Console/Hawk/Sandbox.hs
+++ b/src/System/Console/Hawk/Sandbox.hs
@@ -13,37 +13,38 @@
 --   limitations under the License.
 
 -- Extra steps to be performed if hawk was installed from a sandbox.
--- 
+--
 -- Extra steps are needed because the hawk binary needs runtime access
 -- to the hawk library, but the hint library only knows about the globally-
 -- installed libraries. If hawk has been installed with a sandbox, its
 -- binary and its library will be installed in a local folder instead of
 -- in the global location.
-{-# LANGUAGE TemplateHaskell, TupleSections #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections   #-}
 module System.Console.Hawk.Sandbox
     ( extraGhcArgs
     , runHawkInterpreter
     ) where
 
-import Control.Applicative
-import Control.Monad
-import Data.List.Extra (wordsBy)
-import Data.Maybe
-import Language.Haskell.Interpreter (InterpreterT, InterpreterError)
-import Language.Haskell.Interpreter.Unsafe (unsafeRunInterpreterWithArgs)
-import Language.Haskell.TH.Syntax (lift, runIO)
-import System.Directory.PathFinder
-import System.Environment (getEnvironment)
-import System.FilePath ((</>))
-import Text.Printf (printf)
+import           Control.Monad
+import           Data.List.Extra                     (wordsBy)
+import           Data.Maybe
+import           Language.Haskell.Interpreter        (InterpreterError,
+                                                      InterpreterT)
+import           Language.Haskell.Interpreter.Unsafe (unsafeRunInterpreterWithArgs)
+import           Language.Haskell.TH.Syntax          (lift, runIO)
+import           System.Directory.PathFinder
+import           System.Environment                  (getEnvironment)
+import           System.FilePath                     ((</>))
+import           Text.Printf                         (printf)
 
 -- magic self-referential module created by cabal
-import Paths_haskell_awk (getBinDir)
+import           Paths_haskell_awk                   (getBinDir)
 
 
 data Sandbox = Sandbox
   { sandboxPathFinder :: PathFinder
-  , packageDbFinder :: MultiPathFinder
+  , packageDbFinder   :: MultiPathFinder
   }
 
 dotCabal :: Sandbox
@@ -119,10 +120,10 @@ extraGhcArgs = fmap (printf "-package-db %s") <$> detectPackageDbs
 
 -- | a version of runInterpreter which can load libraries
 --   installed along hawk's sandbox folder, if applicable.
--- 
+--
 -- Must be called inside a `withLock` block, otherwise hint will generate
 -- conflicting temporary files.
--- 
+--
 -- TODO: Didn't we write a patch for hint about this?
 --       Do we still need the lock?
 runHawkInterpreter :: InterpreterT IO a -> IO (Either InterpreterError a)

--- a/src/System/Console/Hawk/UserExpr/CanonicalExpr.hs
+++ b/src/System/Console/Hawk/UserExpr/CanonicalExpr.hs
@@ -1,17 +1,16 @@
 module System.Console.Hawk.UserExpr.CanonicalExpr where
 
 
-import qualified Data.ByteString.Lazy.Char8 as B
+import qualified Data.ByteString.Lazy.Char8                  as B
 
-import Control.Applicative
-import Data.HaskellExpr
-import Data.HaskellExpr.Base
-import System.Console.Hawk.Args
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.Base
-import System.Console.Hawk.Runtime.HaskellExpr
-import System.Console.Hawk.UserExpr.InputReadyExpr
-import System.Console.Hawk.UserExpr.OriginalExpr
+import           Data.HaskellExpr
+import           Data.HaskellExpr.Base
+import           System.Console.Hawk.Args
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.Base
+import           System.Console.Hawk.Runtime.HaskellExpr
+import           System.Console.Hawk.UserExpr.InputReadyExpr
+import           System.Console.Hawk.UserExpr.OriginalExpr
 
 
 -- | Regardless of the requested input format, we currently convert all user expressions

--- a/src/System/Console/Hawk/UserExpr/InputReadyExpr.hs
+++ b/src/System/Console/Hawk/UserExpr/InputReadyExpr.hs
@@ -1,14 +1,13 @@
 module System.Console.Hawk.UserExpr.InputReadyExpr where
 
 
-import qualified Data.ByteString.Lazy.Char8 as B
+import qualified Data.ByteString.Lazy.Char8                as B
 
-import Control.Applicative
-import Data.HaskellExpr
-import Data.HaskellExpr.Base
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.HaskellExpr
-import System.Console.Hawk.UserExpr.OriginalExpr
+import           Data.HaskellExpr
+import           Data.HaskellExpr.Base
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.HaskellExpr
+import           System.Console.Hawk.UserExpr.OriginalExpr
 
 
 -- | While the original user input may describe a value or a function on a

--- a/src/System/Console/Hawk/UserPrelude.hs
+++ b/src/System/Console/Hawk/UserPrelude.hs
@@ -1,15 +1,14 @@
 -- | In which the user prelude is massaged into the form hint needs.
 module System.Console.Hawk.UserPrelude where
 
-import Control.Applicative
-import Control.Monad.Trans.Class
-import Data.ByteString as B
-import Text.Printf
+import           Control.Monad.Trans.Class
+import           Data.ByteString                        as B
+import           Text.Printf
 
-import Control.Monad.Trans.Uncertain
-import Data.HaskellModule
-import System.Console.Hawk.Sandbox
-import System.Console.Hawk.UserPrelude.Extend
+import           Control.Monad.Trans.Uncertain
+import           Data.HaskellModule
+import           System.Console.Hawk.Sandbox
+import           System.Console.Hawk.UserPrelude.Extend
 
 
 type UserPrelude = HaskellModule
@@ -29,7 +28,7 @@ testC f = do
 -- import Prelude
 -- import qualified Data.ByteString.Lazy.Char8 as B
 -- import qualified Data.List as L
--- 
+--
 -- >>> testC "moduleName"
 -- module MyPrelude where
 -- import Prelude
@@ -58,6 +57,6 @@ compileUserPreludeWithArgs :: [String] -- ^ extra ghc args
                            -> UserPrelude
                            -> UncertainT IO ()
 compileUserPreludeWithArgs args orig f m = do
-    extraArgs <- lift $ extraGhcArgs
-    let args' = (extraArgs ++ args)
+    extraArgs <- lift extraGhcArgs
+    let args' = extraArgs ++ args
     compileModuleWithArgs args' orig f m

--- a/src/System/Console/Hawk/UserPrelude/Defaults.hs
+++ b/src/System/Console/Hawk/UserPrelude/Defaults.hs
@@ -1,9 +1,9 @@
 -- | The user prelude you get if the user doesn't have a prelude.
 module System.Console.Hawk.UserPrelude.Defaults where
 
-import Control.Arrow ((&&&))
+import           Control.Arrow      ((&&&))
 
-import Data.HaskellModule
+import           Data.HaskellModule
 
 
 -- | Imported at runtime even if missing from the user prelude.
@@ -22,7 +22,7 @@ defaultModules =
       , "Data.ByteString.Lazy.Char8"
       ]
   where
-    fullyQualified = (id &&& Just)
+    fullyQualified = id &&& Just
 
 defaultPrelude :: String
 defaultPrelude = unlines

--- a/src/System/Console/Hawk/UserPrelude/Extend.hs
+++ b/src/System/Console/Hawk/UserPrelude/Extend.hs
@@ -4,11 +4,11 @@ module System.Console.Hawk.UserPrelude.Extend
   , extendImports
   ) where
 
-import Control.Applicative
-import Data.Maybe
+import           Control.Applicative                      (liftA2)
+import           Data.Maybe
 
-import Data.HaskellModule
-import System.Console.Hawk.UserPrelude.Defaults
+import           Data.HaskellModule
+import           System.Console.Hawk.UserPrelude.Defaults
 
 
 -- | We cannot import a module unless it has a name.
@@ -23,7 +23,7 @@ moduleNames :: HaskellModule -> [String]
 moduleNames = map fst . importedModules
 
 -- | GHC imports the Haskell Prelude by default, but hint doesn't.
--- 
+--
 -- >>> let m name = (name, Nothing)
 -- >>> :{
 --   let testM exts modules = moduleNames m'
@@ -33,16 +33,16 @@ moduleNames = map fst . importedModules
 --           m2  = foldr addImport m1 modules
 --           m' = extendImports m2
 -- :}
--- 
+--
 -- >>> testM [] []
 -- ["Prelude"]
--- 
+--
 -- >>> testM [] [m "Data.Maybe"]
 -- ["Prelude","Data.Maybe"]
--- 
+--
 -- >>> testM [] [m "Data.Maybe", m "Prelude", m "Data.Either"]
 -- ["Data.Maybe","Prelude","Data.Either"]
--- 
+--
 -- >>> :{
 -- testM [] [ ("Data.Maybe", Just "M")
 --          , ("Prelude", Just "P")
@@ -50,7 +50,7 @@ moduleNames = map fst . importedModules
 --          ]
 -- :}
 -- ["Data.Maybe","Prelude","Data.Either"]
--- 
+--
 -- >>> :{
 -- testM ["OverloadedStrings","NoImplicitPrelude"]
 --       [m "Data.Maybe"]
@@ -63,7 +63,7 @@ extendImports = until preludeOk
     prelude = "Prelude"
     noPrelude = "NoImplicitPrelude"
     unqualified_prelude = (prelude, Nothing)
-    
+
     preludeOk = liftA2 (||) hasPrelude noImplicitPrelude
     hasPrelude        m =   prelude `elem` moduleNames m
     noImplicitPrelude m = noPrelude `elem` languageExtensions m

--- a/src/System/Directory/Extra.hs
+++ b/src/System/Directory/Extra.hs
@@ -1,23 +1,22 @@
 -- | For functions which should have been System.Directory
 module System.Directory.Extra where
 
-import Data.List
-import System.FilePath
+import           Data.List
+import           System.FilePath
 
 
 -- | Only works with absolute paths.
--- 
+--
 -- >>> ancestors "/bin"
 -- ["/","/bin"]
--- 
+--
 -- >>> ancestors "/bin/foo/bar"
 -- ["/","/bin","/bin/foo","/bin/foo/bar"]
 ancestors :: FilePath -> [FilePath]
 ancestors absPath = absPaths
   where
-    (drive, fullRelPath) = splitDrive absPath 
-    reconstruct relPath = joinDrive drive relPath
-    
+    (drive, fullRelPath) = splitDrive absPath
+    reconstruct = joinDrive drive
     components = splitDirectories fullRelPath
     relPaths = map joinPath (inits components)
     absPaths = map reconstruct relPaths

--- a/src/System/Directory/PathFinder.hs
+++ b/src/System/Directory/PathFinder.hs
@@ -2,17 +2,15 @@
 {-# LANGUAGE LambdaCase #-}
 module System.Directory.PathFinder where
 
-import Control.Monad
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.List
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.State
-import Data.List
-import System.Directory
-import System.FilePath
-
-import System.Directory.Extra
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.List
+import           Control.Monad.Trans.Maybe
+import           Control.Monad.Trans.State
+import           Data.List
+import           System.Directory
+import           System.FilePath
 
 
 type PathFinder = StateT FilePath (MaybeT IO) ()

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -12,16 +12,15 @@
 --   See the License for the specific language governing permissions and
 --   limitations under the License.
 
-import Control.Applicative
-import Data.List
+import           Data.List
 import qualified System.Console.Hawk.Representable.Test as ReprTest
-import qualified System.Console.Hawk.Test as HawkTest
-import System.FilePath
-import System.Environment
-import Text.Printf
+import qualified System.Console.Hawk.Test               as HawkTest
+import           System.Environment
+import           System.FilePath
+import           Text.Printf
 
-import Test.DocTest (doctest)
-import Test.Hspec (hspec)
+import           Test.DocTest                           (doctest)
+import           Test.Hspec                             (hspec)
 
 
 substSuffix :: Eq a => [a] -> [a] -> [a] -> [a]
@@ -34,15 +33,15 @@ substSuffix _ _ xs = xs
 doctest' :: String -> IO ()
 doctest' file = do
     exePath <- dropExtension <$> getExecutablePath
-    
+
     let srcPath = "src"
     let autogenPath = substSuffix ("reference" </> "reference")
                                   "autogen"
                                   exePath
-    
+
     let includeSrc      = printf "-i%s" srcPath
     let includeAutogen  = printf "-i%s" autogenPath
-    
+
     doctest [includeSrc, includeAutogen, file]
 
 main :: IO ()

--- a/tests/System/Console/Hawk/Representable/Test.hs
+++ b/tests/System/Console/Hawk/Representable/Test.hs
@@ -12,17 +12,18 @@
 --   See the License for the specific language governing permissions and
 --   limitations under the License.
 
-{-# LANGUAGE ExtendedDefaultRules,OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE OverloadedStrings    #-}
 module System.Console.Hawk.Representable.Test where
 
-import Data.Map (Map)
-import qualified Data.Map as M
-import Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Map                          (Map)
+import qualified Data.Map                          as M
+import           Data.Set                          (Set)
+import qualified Data.Set                          as S
 
-import System.Console.Hawk.Representable
+import           System.Console.Hawk.Representable
 
-import Test.Hspec 
+import           Test.Hspec
 
 
 -- explicitly type all values to avoid warnings.
@@ -35,7 +36,7 @@ emptyString,word,word_word,w_w :: String
 
 
 reprSpec' :: Spec
-reprSpec' = describe "repr'" $ do
+reprSpec' = describe "repr'" $
     it "can convert tuple values" $ do
       example $ repr' " " (_1,True) `shouldBe` "1 True"
       example $ repr' " " (_1,True,_2) `shouldBe` "1 True 2"
@@ -68,7 +69,7 @@ reprSpec = describe "repr" $ do
     it "can convert integer values" $ example $
         repr "\t" (1::Integer) `shouldBe` ["1"]
 
-    it "can convert maybe values" $ do 
+    it "can convert maybe values" $ do
         example $ repr "\t" (Nothing::Maybe ()) `shouldBe` [""]
         example $ repr "\t" (Just 1::Maybe Int) `shouldBe` ["1"]
         example $ repr "\t" (Just (Just True)) `shouldBe` ["True"]
@@ -105,9 +106,9 @@ reprSpec = describe "repr" $ do
     it "can convert map values" $ do
         repr "\t" (M.empty::Map Bool Bool) `shouldBe` []
         example $ repr "\t" (M.fromList [(_1,_2),(_3,_4)]) `shouldBe` ["1\t2","3\t4"]
-        example $ repr "\t" ([M.fromList [(_1,_2),(_3,_4)]]) `shouldBe` ["1 2\t3 4"]
+        example $ repr "\t" [M.fromList [(_1,_2),(_3,_4)]] `shouldBe` ["1 2\t3 4"]
 
     it "can convert set values" $ do
         repr "\t" (S.empty::Set Bool) `shouldBe` []
         example $ repr "\t" (S.fromList [_1,_2,_3,_4]) `shouldBe` ["1","2","3","4"]
-        example $ repr "\t" ([S.fromList [_1,_2]]) `shouldBe` ["1\t2"]
+        example $ repr "\t" [S.fromList [_1,_2]] `shouldBe` ["1\t2"]

--- a/tests/System/Console/Hawk/Test.hs
+++ b/tests/System/Console/Hawk/Test.hs
@@ -15,13 +15,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module System.Console.Hawk.Test where
 
-import System.Directory
-import System.IO
-import Test.Hspec
-import Test.HUnit
-import GHC.IO.Handle
+import           GHC.IO.Handle
+import           System.Directory
+import           System.IO
+import           Test.Hspec
+import           Test.HUnit
 
-import System.Console.Hawk
+import           System.Console.Hawk
 
 
 run :: IO ()
@@ -36,14 +36,14 @@ run = withContextHSpec $ \itEval itApply itMap ->
           itEval "[[1]]" `into` "1\n"
           itEval "[[1,2]]" `into` "1 2\n"
           itEval "[[1,2],[3,4]]" `into` "1 2\n3 4\n"
-          
+
           itApply "id" `onInput` "foo" `into` "foo\n"
           itApply "L.transpose" `onInput` "1 2\n3 4" `into` "1 3\n2 4\n"
           itApply "L.map (!! 1)" `onInput` "1 2\n3 4" `into` "2\n4\n"
 
           itMap "(!! 1)" `onInput` "1 2\n3 4" `into` "2\n4\n"
-  where onInput f x = f x
-        into f x = f x
+  where onInput f = f
+        into f = f
 
 withContextHSpec :: ((String -> String -> Spec)
                     -> (String -> String -> String -> Spec)
@@ -60,7 +60,7 @@ withContextHSpec body = do
              (tmpf, tmph) <- openTempFile tmpd "hawk_input"
              hPutStr tmph input
              hClose tmph
-             out <- catchOutput $ do
+             out <- catchOutput $
                processArgs $ concat [ ["-c", "tests/preludes/default"]
                                     , flags
                                     , [expr, tmpf]
@@ -68,7 +68,7 @@ withContextHSpec body = do
              removeFile tmpf
              assertEqual descr expected out
   let [itApply,itMap] = map it' [["-a"],["-m"]]
-  let itEval expr expected = it' [] expr "" expected
+  let itEval expr = it' [] expr ""
   hspec $ body itEval itApply itMap
 
 

--- a/tests/System/Console/Hawk/TestUtils.hs
+++ b/tests/System/Console/Hawk/TestUtils.hs
@@ -14,23 +14,13 @@
 
 module System.Console.Hawk.TestUtils where
 
-import Control.Applicative
-  ( (<$>) )
-import Control.Exception
-  ( bracket_ )
-import Data.List
-  ( isSuffixOf
-  , isPrefixOf )
-import System.Directory
-  ( createDirectory 
-  , getDirectoryContents
-  , getTemporaryDirectory
-  , removeFile
-  , removeDirectoryRecursive)
-import System.FilePath
-  ( (</>)
-  , dropExtension
-  , takeExtension)
+import           Control.Applicative ((<$>))
+import           Control.Exception   (bracket_)
+import           Data.List           (isPrefixOf, isSuffixOf)
+import           System.Directory    (createDirectory, getDirectoryContents,
+                                      getTemporaryDirectory,
+                                      removeDirectoryRecursive, removeFile)
+import           System.FilePath     (dropExtension, takeExtension, (</>))
 
 
 nextFilePath :: FilePath -- ^ directory
@@ -58,11 +48,11 @@ withTempFilePath :: FilePath -- ^ directory
 withTempFilePath dir template action isDir = do
     let pre = dropExtension template
     let post = takeExtension template
-    tempFileName <- ((</>) dir) <$> nextFilePath dir pre post
+    tempFileName <- (dir </>) <$> nextFilePath dir pre post
     bracket_ (create tempFileName) (delete tempFileName) (action tempFileName)
   where create fp = if isDir
                       then createDirectory fp
-                      else writeFile fp "" 
+                      else writeFile fp ""
         delete fp = if isDir
                       then removeDirectoryRecursive fp
                       else removeFile fp


### PR DESCRIPTION
Removed compilation warnings:  …
  - The import of ‘package.Type’ is redundant
  - Redundant constraint: SomeType s
  - Pattern matches are non-exhaustive
  - only import Applicative's liftA2 or (<$>) instead of complete Applicative

Removed various hlint warnings
  - eta reduction
  - redundant do
  - redundant brackets
  - redundant guard
  - redundant $
  - use concatMap
  - use unless

Added .vscode/ to to be ignored.
