### PR TITLE
Fix address compiler warnings

### DIFF
--- a/runtime/System/Console/Hawk/Representable.hs
+++ b/runtime/System/Console/Hawk/Representable.hs
@@ -24,14 +24,13 @@ module System.Console.Hawk.Representable (
 
 ) where
 
-import Prelude
-import Data.ByteString.Lazy.Char8 (ByteString)
+import           Data.ByteString.Lazy.Char8 (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as C8 hiding (hPutStrLn)
 import qualified Data.List as L
-import Data.Set (Set)
-import qualified Data.Set as S
-import Data.Map (Map)
+import           Data.Map (Map)
 import qualified Data.Map as M
+import           Data.Set (Set)
+import qualified Data.Set  as S
 
 
 -- | A type that instantiate ListAsRow is a type that has a representation
@@ -158,7 +157,7 @@ instance Row ByteString where
     repr' _ = id
 
 instance (Row a) => Row (Maybe a) where
-    repr' _ Nothing = C8.empty
+    repr' _ Nothing  = C8.empty
     repr' d (Just x) = repr' d x -- check if d is correct here
 
 instance (Row a,Row b) => Row (a,b) where
@@ -257,7 +256,7 @@ instance ListAsRows Int
 instance ListAsRows Integer
 instance (Row a) => ListAsRows (Maybe a)
 instance ListAsRows ()
-instance (ListAsRow a,ListAsRows a) => ListAsRows [a]
+instance (ListAsRow a) => ListAsRows [a]
 instance (Row a,Row b) => ListAsRows (a,b)
 instance (Row a,Row b,Row c) => ListAsRows (a,b,c)
 instance (Row a,Row b,Row c,Row d) => ListAsRows (a,b,c,d)
@@ -274,7 +273,7 @@ instance (Row a,Row b,Row c,Row d,Row e,Row f,Row g,Row h,Row i,Row l)
 instance ListAsRows Char where
     listRepr _ = (:[]) . C8.pack
 
-instance (ListAsRow a,ListAsRows a) => ListAsRows (Set a) where
+instance (ListAsRow a) => ListAsRows (Set a) where
     listRepr d = listRepr d . L.map S.toList
 
 instance (Row a,Row b) => ListAsRows (Map a b) where

--- a/runtime/System/Console/Hawk/Runtime.hs
+++ b/runtime/System/Console/Hawk/Runtime.hs
@@ -6,16 +6,15 @@ module System.Console.Hawk.Runtime
   , processTable
   ) where
 
-import Control.Applicative
-import Control.Exception
-import Data.ByteString.Lazy.Char8 as B
-import Data.ByteString.Lazy.Search as Search
-import GHC.IO.Exception
-import System.IO
+import           Control.Exception
+import           Data.ByteString.Lazy.Char8 as B
+import           Data.ByteString.Lazy.Search as Search
+import           GHC.IO.Exception
+import           System.IO
 
-import System.Console.Hawk.Args.Spec
-import System.Console.Hawk.Representable
-import System.Console.Hawk.Runtime.Base
+import           System.Console.Hawk.Args.Spec
+import           System.Console.Hawk.Representable
+import           System.Console.Hawk.Runtime.Base
 
 
 data SomeRows = forall a. Rows a => SomeRows a
@@ -34,8 +33,8 @@ getTable spec = splitIntoTable' <$> getInputString'
     getInputString' = getInputString (inputSource spec)
 
 getInputString :: InputSource -> IO B.ByteString
-getInputString NoInput = return B.empty
-getInputString UseStdin = B.getContents
+getInputString NoInput       = return B.empty
+getInputString UseStdin      = B.getContents
 getInputString (InputFile f) = B.readFile f
 
 -- [[contents]]
@@ -54,7 +53,7 @@ splitIntoTable (Records sep format) = fmap splitIntoFields' . splitIntoRecords'
 -- or
 -- [field0, field1, ...]
 splitIntoFields :: RecordFormat -> B.ByteString -> [B.ByteString]
-splitIntoFields RawRecord = return
+splitIntoFields RawRecord    = return
 splitIntoFields (Fields sep) = splitAtSeparator sep
 
 splitAtSeparator :: Separator -> B.ByteString -> [B.ByteString]
@@ -81,7 +80,7 @@ outputRows (OutputSpec _ spec) x = ignoringBrokenPipe $ do
   where
     join' = join (B.fromStrict $ recordDelimiter spec)
     toRows = repr (B.fromStrict $ fieldDelimiter spec)
-    
+
     join :: B.ByteString -> [B.ByteString] -> B.ByteString
     join "\n" = B.unlines
     join sep  = B.intercalate sep

--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -165,7 +165,7 @@ runOptionParserT = runOptionParserWith shortName longName helpMsg optionType
 --   }
 -- :}
 -- (True,False,True)
-runOptionParserWith :: (Eq o, Monad m)
+runOptionParserWith :: (Monad m)
                     => (o -> Char)
                     -> (o -> String)
                     -> (o -> [String])
@@ -435,7 +435,7 @@ consumeLast o defaultValue consume = do
 
 
 -- | For use with mutually-exclusive flags.
-consumeExclusive :: (Option o, Functor m, Monad m)
+consumeExclusive :: (Option o, Monad m)
                  => [(o, a)] -> a -> OptionParserT o m a
 consumeExclusive = consumeExclusiveWith longName
 
@@ -453,7 +453,7 @@ consumeExclusive = consumeExclusiveWith longName
 -- >>> testP ["-cs"] tp consume
 -- error: cowbell and saxophone are incompatible
 -- *** Exception: ExitFailure 1
-consumeExclusiveWith :: (Eq o, Functor m, Monad m)
+consumeExclusiveWith :: (Eq o, Monad m)
                      => (o -> String)
                      -> [(o, a)] -> a -> OptionParserT o m a
 consumeExclusiveWith longName' assoc defaultValue = do
@@ -482,7 +482,7 @@ consumeExclusiveWith longName' assoc defaultValue = do
 --
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume >> consume)
 -- Nothing
-consumeExtra :: (Functor m, Monad m)
+consumeExtra :: (Monad m)
              => OptionConsumer m a -> OptionParserT o m (Maybe a)
 consumeExtra consume = OptionParserT $ do
     extra_options <- lift get
@@ -505,7 +505,7 @@ consumeExtra consume = OptionParserT $ do
 --
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume)
 -- []
-consumeExtras :: (Functor m, Monad m)
+consumeExtras :: (Monad m)
               => OptionConsumer m a -> OptionParserT o m [a]
 consumeExtras consume = fmap reverse $ go []
   where

--- a/src/Control/Monad/Trans/State/Persistent.hs
+++ b/src/Control/Monad/Trans/State/Persistent.hs
@@ -19,18 +19,18 @@ import System.IO
 
 
 -- | Read and write the cache to a file. Not atomic.
--- 
+--
 -- >>> :{
 -- do { exists <- doesFileExist f
 --    ; when exists $ removeFile f
 --    }
 -- :}
--- 
+--
 -- >>> withPersistentState f 0 $ modify (+1) >> get
 -- 1
 -- >>> withPersistentState f 0 $ modify (+1) >> get
 -- 2
--- 
+--
 -- >>> removeFile f
 withPersistentState :: forall s a. (Read s, Show s, Eq s)
                     => FilePath -> s -> State s a -> IO a
@@ -41,33 +41,33 @@ withPersistentState f default_s sx = do
     sTx = mapStateT (return . runIdentity) sx
 
 -- | A monad-transformer version of `withPersistentState`.
--- 
+--
 -- >>> :{
 -- do { exists <- doesFileExist f
 --    ; when exists $ removeFile f
 --    }
 -- :}
--- 
+--
 -- >>> withPersistentStateT f 0 $ lift (putStrLn "hello") >> modify (+1) >> get
 -- hello
 -- 1
 -- >>> withPersistentStateT f 0 $ lift (putStrLn "hello") >> modify (+1) >> get
 -- hello
 -- 2
--- 
--- 
+--
+--
 -- If the contents of the file has been corrupted, revert to the default value.
--- 
+--
 -- >>> withPersistentStateT f "." $ lift (putStrLn "hello") >> modify (++".") >> get
 -- hello
 -- ".."
 -- >>> withPersistentStateT f "." $ lift (putStrLn "hello") >> modify (++".") >> get
 -- hello
 -- "..."
--- 
--- 
+--
+--
 -- >>> removeFile f
-withPersistentStateT :: forall m s a. (Functor m, MonadIO m, Read s, Show s, Eq s)
+withPersistentStateT :: forall m s a. (MonadIO m, Read s, Show s, Eq s)
                      => FilePath -> s -> StateT s m a -> m a
 withPersistentStateT f default_s sx = do
     Just s <- runMaybeT (get_s <|> get_default_s)
@@ -80,7 +80,7 @@ withPersistentStateT f default_s sx = do
     get_s = do
         exists <- liftIO $ doesFileExist f
         guard exists
-        
+
         -- close the file even if the parsing fails
         Just s <- liftIO $ withFile f ReadMode $ \h -> do
           file_contents <- hGetContents h
@@ -88,14 +88,14 @@ withPersistentStateT f default_s sx = do
             [(s, "")] -> return (Just s)
             _         -> return Nothing
         return s
-    
+
     get_default_s :: MaybeT m s
     get_default_s = return default_s
 
 
 -- | Combine consecutive StateT transformers into a single StateT, so the state
 --   can be persisted to a single file.
--- 
+--
 -- >>> let sx = modify (+10)       :: StateT Int (State Int) ()
 -- >>> let tx = lift $ modify (*2) :: StateT Int (State Int) ()
 -- >>> execState (withCombinedState $ sx >> tx) (1, 2)

--- a/src/Control/Monad/Trans/Uncertain.hs
+++ b/src/Control/Monad/Trans/Uncertain.hs
@@ -236,7 +236,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 -- after
 -- warning: be careful!
 -- 42
-wrapUncertain :: (Monad m, Monad m')
+wrapUncertain :: (Monad m')
               => (forall a. m a -> m' a)
               -> (UncertainT m b -> UncertainT m' b)
 wrapUncertain wrap body = wrapUncertainArg wrap' body'
@@ -277,7 +277,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 -- after
 -- warning: be careful!
 -- 43
-wrapUncertainArg :: (Monad m, Monad m')
+wrapUncertainArg :: (Monad m')
                  => (forall a. (v -> m a) -> m' a)
                  -> ((v -> UncertainT m b) -> UncertainT m' b)
 wrapUncertainArg wrap body = do

--- a/src/Control/Monad/Trans/Uncertain.hs
+++ b/src/Control/Monad/Trans/Uncertain.hs
@@ -2,14 +2,13 @@
 -- | A computation which may raise warnings or fail in error.
 module Control.Monad.Trans.Uncertain where
 
-import Control.Applicative
-import "mtl" Control.Monad.Trans
-import "mtl" Control.Monad.Identity
-import "transformers" Control.Monad.Trans.Error hiding (Error)
-import "transformers" Control.Monad.Trans.Writer
-import System.Exit
-import System.IO
-import Text.Printf
+import           "mtl" Control.Monad.Identity
+import           "mtl" Control.Monad.Trans
+import           "transformers" Control.Monad.Trans.Error hiding (Error)
+import           "transformers" Control.Monad.Trans.Writer
+import           System.Exit
+import           System.IO
+import           Text.Printf
 
 
 type Warning = String
@@ -58,7 +57,7 @@ multilineMsg = concat . map (printf "\n  %s") . lines
 --   multilineWarn "foo\nbar\n"
 --   return 42
 -- :}
--- warning: 
+-- warning:
 --   foo
 --   bar
 -- 42
@@ -71,7 +70,7 @@ multilineWarn = warn . multilineMsg
 --   multilineFail "foo\nbar\n"
 --   return 42
 -- :}
--- error: 
+-- error:
 --   foo
 --   bar
 -- *** Exception: ExitFailure 1
@@ -92,9 +91,9 @@ uncertainT (Right x, warnings) = mapM_ warn warnings >> return x
 
 -- | A version of `runWarnings` which allows you to interleave IO actions
 --   with uncertain actions.
--- 
+--
 -- Note that the warnings are displayed after the IO's output.
--- 
+--
 -- >>> :{
 -- runWarningsIO $ do
 --   warn "before"
@@ -106,7 +105,7 @@ uncertainT (Right x, warnings) = mapM_ warn warnings >> return x
 -- warning: before
 -- warning: after
 -- Right 42
--- 
+--
 -- >>> :{
 -- runWarningsIO $ do
 --   warn "before"
@@ -125,7 +124,7 @@ runWarningsIO u = do
 
 -- | A version of `runUncertain` which only prints the warnings, not the
 --   errors. Unlike `runUncertain`, it doesn't terminate on error.
--- 
+--
 -- >>> :{
 -- runWarnings $ do
 --   warn "before"
@@ -135,7 +134,7 @@ runWarningsIO u = do
 -- warning: before
 -- warning: after
 -- Right 42
--- 
+--
 -- >>> :{
 -- runWarnings $ do
 --   warn "before"
@@ -150,9 +149,9 @@ runWarnings = runWarningsIO . mapUncertainT (return . runIdentity)
 
 -- | A version of `runUncertain` which allows you to interleave IO actions
 --   with uncertain actions.
--- 
+--
 -- Note that the warnings are displayed after the IO's output.
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "before"
@@ -164,7 +163,7 @@ runWarnings = runWarningsIO . mapUncertainT (return . runIdentity)
 -- warning: before
 -- warning: after
 -- 42
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "before"
@@ -186,9 +185,9 @@ runUncertainIO u = do
       Right x -> return x
 
 -- | Print warnings and errors, terminating on error.
--- 
+--
 -- Note that the warnings are displayed even if there is also an error.
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "first"
@@ -206,7 +205,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 
 -- | Upgrade an `IO a -> IO a` wrapping function into a variant which uses
 --   `UncertainT IO` instead of `IO`.
--- 
+--
 -- >>> :{
 -- let wrap body = do { putStrLn "before"
 --                    ; r <- body
@@ -214,7 +213,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 --                    ; return r
 --                    }
 -- :}
--- 
+--
 -- >>> :{
 -- wrap $ do { putStrLn "hello"
 --           ; return 42
@@ -224,7 +223,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 -- hello
 -- after
 -- 42
--- 
+--
 -- >>> :{
 -- runUncertainIO $ wrapUncertain wrap
 --                $ do { lift $ putStrLn "hello"
@@ -247,7 +246,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 
 -- | A version of `wrapUncertain` for wrapping functions of type
 --   `(Handle -> IO a) -> IO a`.
--- 
+--
 -- >>> :{
 -- let wrap body = do { putStrLn "before"
 --                    ; r <- body 42
@@ -255,7 +254,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 --                    ; return r
 --                    }
 -- :}
--- 
+--
 -- >>> :{
 -- wrap $ \x -> do { putStrLn "hello"
 --                 ; return (x + 1)
@@ -265,7 +264,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 -- hello
 -- after
 -- 43
--- 
+--
 -- >>> :{
 -- runUncertainIO $ wrapUncertainArg wrap
 --                $ \x -> do { lift $ putStrLn "hello"
@@ -283,7 +282,7 @@ wrapUncertainArg :: (Monad m, Monad m')
                  -> ((v -> UncertainT m b) -> UncertainT m' b)
 wrapUncertainArg wrap body = do
     (r, ws) <- lift $ wrap $ runUncertainT . body
-    
+
     -- repackage the warnings and errors
     mapM_ warn ws
     fromRightM r

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE PackageImports #-}
 -- | A generic caching interface.
--- 
+--
 -- The intent is to support many concrete implementations,
 -- and to use specify caching policies using combinators.
--- 
+--
 -- Note that even though we _support_ many concrete implementations,
 -- for simplicity we only provide one based on an association-list.
 module Data.Cache where
@@ -47,9 +47,9 @@ cached c k computeSlowly = do
 
 
 -- | A dummy cache which never caches anything.
--- 
+--
 -- Semantically equivalent to `finiteCache 0 $ assocCache`, except for the `m`.
--- 
+--
 -- >>> withNullCache testC
 -- one
 -- two
@@ -71,7 +71,7 @@ withNullCache body = body nullCache
 
 
 -- | A very inefficient example implementation.
--- 
+--
 -- >>> withAssocCache testC
 -- one
 -- two
@@ -97,14 +97,14 @@ withAssocCache body = evalStateT (body assocCache) []
 
 -- | Only cache the first `n` requests (use n=-1 for unlimited).
 --   Combine with a cache policy in order to reuse those `n` slots.
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 2 $ testC
 -- one
 -- two
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 1 $ testC
 -- one
 -- two
@@ -112,7 +112,7 @@ withAssocCache body = evalStateT (body assocCache) []
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 0 $ testC
 -- one
 -- two
@@ -121,7 +121,7 @@ withAssocCache body = evalStateT (body assocCache) []
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache (-1) $ testC
 -- one
 -- two
@@ -154,13 +154,13 @@ withFiniteCache n body c = evalStateT (body $ finiteCache n c) 0
 
 
 -- | An example cache-policy implementation: Least-Recently-Used.
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 2 $ withLruCache testC
 -- one
 -- two
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 1 $ withLruCache testC
 -- one
 -- two
@@ -168,7 +168,7 @@ withFiniteCache n body c = evalStateT (body $ finiteCache n c) 0
 -- two
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 0 $ withLruCache testC
 -- one
 -- two
@@ -204,7 +204,7 @@ lruCache c = Cache
           [] -> do
             -- the cache is both full and empty? try to reset.
             lift $ clearCache c
-    
+
     write  k = modify (k:)
     remove k = modify $ filter $ (/= k)
 
@@ -215,9 +215,9 @@ withLruCache body c = evalStateT (body $ lruCache c) []
 
 
 -- | An extreme version of the LRU strategy.
--- 
+--
 -- Semantically equivalent to `lruCache . finiteCache 1`, except for the `m`.
--- 
+--
 -- >>> withAssocCache $ withSingletonCache testC
 -- one
 -- two
@@ -225,12 +225,12 @@ withLruCache body c = evalStateT (body $ lruCache c) []
 -- two
 -- testing
 -- [3,3,3,3,7,7]
-singletonCache :: (Monad m, Eq k) => Cache m k a -> Cache m k a
+singletonCache :: (Monad m) => Cache m k a -> Cache m k a
 singletonCache c = c { writeCache = go }
   where
     go k mx = clearCache c >> writeCache c k mx
 
-withSingletonCache :: (Monad m, Eq k)
+withSingletonCache :: (Monad m)
                    => (Cache m k v -> m a)
                    -> (Cache m k v -> m a)
 withSingletonCache body c = body (singletonCache c)

--- a/src/Language/Haskell/Exts/Location.hs
+++ b/src/Language/Haskell/Exts/Location.hs
@@ -56,6 +56,11 @@ instance Location Decl where
   location (SpecInlineSig    loc _ _ _ _)       = Just loc
   location (InstSig          loc _ _ _ _)       = Just loc
   location (AnnPragma        loc _)             = Just loc
+  location (ClosedTypeFamDecl loc _ _ _ _)      = Just loc
+  location (PatSynSig         loc _ _ _ _ _)    = Just loc
+  location (PatSyn            loc _ _ _)        = Just loc
+  location (MinimalPragma     loc _)            = Just loc
+  location (RoleAnnotDecl     loc _ _)          = Just loc
 
 instance Location Match where
   location (Match loc _ _ _ _ _) = Just loc

--- a/src/System/Console/Hawk/Args/Option.hs
+++ b/src/System/Console/Hawk/Args/Option.hs
@@ -30,16 +30,16 @@ delimiter :: OptionType
 delimiter = nullable (Setting "delim")
 
 -- | Interpret escape sequences, but don't worry if they're invalid.
--- 
+--
 -- >>> parseDelimiter ","
 -- ","
--- 
+--
 -- >>> parseDelimiter "\\n"
 -- "\n"
--- 
+--
 -- >>> parseDelimiter "\\t"
 -- "\t"
--- 
+--
 -- >>> parseDelimiter "\\"
 -- "\\"
 parseDelimiter :: String -> ByteString
@@ -48,7 +48,7 @@ parseDelimiter s = pack $ case reads (printf "\"%s\"" s) of
     _          -> s
 
 -- | Almost like a string, except escape sequences are interpreted.
-consumeDelimiter :: (Functor m, Monad m) => OptionConsumer m ByteString
+consumeDelimiter :: (Monad m) => OptionConsumer m ByteString
 consumeDelimiter = fmap parseDelimiter . consumeNullable "" consumeString
 
 instance Option HawkOption where
@@ -61,7 +61,7 @@ instance Option HawkOption where
   shortName Version               = 'v'
   shortName Help                  = 'h'
   shortName ContextDirectory      = 'c'
-  
+
   longName Apply                 = "apply"
   longName Map                   = "map"
   longName FieldDelimiter        = "field-delimiter"
@@ -71,7 +71,7 @@ instance Option HawkOption where
   longName Version               = "version"
   longName Help                  = "help"
   longName ContextDirectory      = "context-directory"
-  
+
   helpMsg Apply                      = ["apply <expr> to the entire table"]
   helpMsg Map                        = ["apply <expr> to each row"]
   helpMsg FieldDelimiter             = ["default whitespace"]
@@ -82,7 +82,7 @@ instance Option HawkOption where
   helpMsg Help                       = ["this help"]
   helpMsg ContextDirectory           = ["<ctx-dir> directory, default is"
                                        ,"'~/.hawk'"]
-  
+
   optionType Apply                 = flag
   optionType Map                   = flag
   optionType FieldDelimiter        = delimiter

--- a/src/System/Console/Hawk/Args/Parse.hs
+++ b/src/System/Console/Hawk/Args/Parse.hs
@@ -2,14 +2,13 @@
 -- | In which Hawk's command-line arguments are structured into a `HawkSpec`.
 module System.Console.Hawk.Args.Parse (parseArgs) where
 
-import Control.Applicative
-import Data.Char                                 (isSpace)
-import "mtl" Control.Monad.Trans
+import           "mtl" Control.Monad.Trans
+import           Data.Char (isSpace)
 
-import Control.Monad.Trans.OptionParser
-import Control.Monad.Trans.Uncertain
-import qualified System.Console.Hawk.Args.Option as Option
+import           Control.Monad.Trans.OptionParser
+import           Control.Monad.Trans.Uncertain
 import           System.Console.Hawk.Args.Option (HawkOption, options)
+import qualified System.Console.Hawk.Args.Option as Option
 import           System.Console.Hawk.Args.Spec
 import           System.Console.Hawk.Context.Dir
 
@@ -22,15 +21,15 @@ type CommonSeparators = (Separator, Separator)
 
 -- | Extract '-D' and '-d'. We perform this step separately because those two
 --   delimiters are used by both the input and output specs.
--- 
+--
 -- >>> let test = testP commonSeparators
--- 
+--
 -- >>> test []
 -- (Delimiter "\n",Whitespace)
--- 
+--
 -- >>> test ["-D\\n", "-d\\t"]
 -- (Delimiter "\n",Delimiter "\t")
--- 
+--
 -- >>> test ["-D|", "-d,"]
 -- (Delimiter "|",Delimiter ",")
 commonSeparators :: (Functor m, Monad m)
@@ -46,7 +45,7 @@ commonSeparators = do
 
 -- | The input delimiters have already been parsed, but we still need to
 --   interpret them and to determine the input source.
--- 
+--
 -- >>> :{
 -- let test = testP $ do { c <- commonSeparators
 --                       ; _ <- consumeExtra consumeString  -- skip expr
@@ -55,19 +54,19 @@ commonSeparators = do
 --                       ; lift $ print $ inputFormat i
 --                       }
 -- :}
--- 
+--
 -- >>> test []
 -- UseStdin
 -- Records (Delimiter "\n") (Fields Whitespace)
--- 
+--
 -- >>> test ["-d", "-a", "L.reverse"]
 -- UseStdin
 -- Records (Delimiter "\n") RawRecord
--- 
+--
 -- >>> test ["-D", "-a", "B.reverse"]
 -- UseStdin
 -- RawStream
--- 
+--
 -- >>> test ["-d:", "-m", "L.head", "/etc/passwd"]
 -- InputFile "/etc/passwd"
 -- Records (Delimiter "\n") (Fields (Delimiter ":"))
@@ -88,7 +87,7 @@ inputSpec (rSep, fSep) = InputSpec <$> source <*> format
 
 -- | The output delimiters take priority over the input delimiters, regardless
 --   of the order in which they appear.
--- 
+--
 -- >>> :{
 -- let test = testP $ do { c <- commonSeparators
 --                       ; o <- outputSpec c
@@ -97,15 +96,15 @@ inputSpec (rSep, fSep) = InputSpec <$> source <*> format
 --                       ; lift $ print (r, f)
 --                       }
 -- :}
--- 
+--
 -- >>> test []
 -- UseStdout
 -- ("\n"," ")
--- 
+--
 -- >>> test ["-D;", "-d", "-a", "L.reverse"]
 -- UseStdout
 -- (";"," ")
--- 
+--
 -- >>> test ["-o\t", "-d,", "-O|"]
 -- UseStdout
 -- ("|","\t")
@@ -124,18 +123,18 @@ outputSpec (r, f) = OutputSpec <$> sink <*> format
 -- | The information we need in order to evaluate a user expression:
 --   the expression itself, and the context in which it should be evaluated.
 --   In Hawk, that context is the user prelude.
--- 
+--
 -- >>> :{
 -- let test = testP $ do { e <- exprSpec
 --                       ; lift $ print $ untypedExpr e
 --                       ; lift $ print $ userContextDirectory (contextSpec e)
 --                       }
 -- :}
--- 
+--
 -- >>> test []
 -- error: missing user expression
 -- *** Exception: ExitFailure 1
--- 
+--
 -- >>> test [""]
 -- error: user expression cannot be empty
 -- *** Exception: ExitFailure 1
@@ -163,9 +162,9 @@ exprSpec = ExprSpec <$> (ContextSpec <$> contextDir)
 
 
 -- | Parse command-line arguments to construct a `HawkSpec`.
--- 
+--
 -- TODO: complain if some arguments are unused (except perhaps "-d" and "-D").
--- 
+--
 -- >>> :{
 -- let test args = do { spec <- runUncertainIO $ parseArgs args
 --                    ; case spec of
@@ -176,27 +175,27 @@ exprSpec = ExprSpec <$> (ContextSpec <$> contextDir)
 --                        Map   e i o -> putStrLn "Map"   >> print (untypedExpr e, inputSource i) >> print (inputFormat i) >> print (recordDelimiter (outputFormat o), fieldDelimiter (outputFormat o))
 --                    }
 -- :}
--- 
+--
 -- >>> test []
 -- Help
--- 
+--
 -- >>> test ["--help"]
 -- Help
--- 
+--
 -- >>> test ["--version"]
 -- Version
--- 
+--
 -- >>> test ["-d\\t", "L.head"]
 -- Eval
 -- "L.head"
 -- ("\n","\t")
--- 
+--
 -- >>> test ["-D\r\n", "-d\\t", "-m", "L.head"]
 -- Map
 -- ("L.head",UseStdin)
 -- Records (Delimiter "\r\n") (Fields (Delimiter "\t"))
 -- ("\r\n","\t")
--- 
+--
 -- >>> test ["-D", "-O\n", "-m", "L.head", "file.in"]
 -- Map
 -- ("L.head",InputFile "file.in")
@@ -216,7 +215,7 @@ parseArgs args = runOptionParserT options parser args
             , (Option.Apply,   apply)
             , (Option.Map,     map')
             ]
-    
+
     help, version, eval, apply, map' :: (Functor m,MonadIO m) => CommonSeparators
                                      -> OptionParserT HawkOption m HawkSpec
     help    _ = return Help

--- a/src/System/Console/Hawk/Args/Parse.hs
+++ b/src/System/Console/Hawk/Args/Parse.hs
@@ -32,7 +32,7 @@ type CommonSeparators = (Separator, Separator)
 --
 -- >>> test ["-D|", "-d,"]
 -- (Delimiter "|",Delimiter ",")
-commonSeparators :: (Functor m, Monad m)
+commonSeparators :: (Monad m)
                  => OptionParserT HawkOption m CommonSeparators
 commonSeparators = do
     r <- lastSep Option.RecordDelimiter defaultRecordSeparator
@@ -70,7 +70,7 @@ commonSeparators = do
 -- >>> test ["-d:", "-m", "L.head", "/etc/passwd"]
 -- InputFile "/etc/passwd"
 -- Records (Delimiter "\n") (Fields (Delimiter ":"))
-inputSpec :: (Functor m, Monad m)
+inputSpec :: (Monad m)
           => CommonSeparators -> OptionParserT HawkOption m InputSpec
 inputSpec (rSep, fSep) = InputSpec <$> source <*> format
   where
@@ -108,7 +108,7 @@ inputSpec (rSep, fSep) = InputSpec <$> source <*> format
 -- >>> test ["-o\t", "-d,", "-O|"]
 -- UseStdout
 -- ("|","\t")
-outputSpec :: (Functor m, Monad m)
+outputSpec :: (Monad m)
            => CommonSeparators -> OptionParserT HawkOption m OutputSpec
 outputSpec (r, f) = OutputSpec <$> sink <*> format
   where
@@ -142,7 +142,7 @@ outputSpec (r, f) = OutputSpec <$> sink <*> format
 -- >>> test ["-D;", "-d", "-a", "L.reverse","-c","somedir"]
 -- "L.reverse"
 -- "somedir"
-exprSpec :: (Functor m, MonadIO m)
+exprSpec :: (MonadIO m)
          => OptionParserT HawkOption m ExprSpec
 exprSpec = ExprSpec <$> (ContextSpec <$> contextDir)
                     <*> expr
@@ -201,7 +201,7 @@ exprSpec = ExprSpec <$> (ContextSpec <$> contextDir)
 -- ("L.head",InputFile "file.in")
 -- RawStream
 -- ("\n"," ")
-parseArgs :: (Functor m,MonadIO m) => [String] -> UncertainT m HawkSpec
+parseArgs :: (MonadIO m) => [String] -> UncertainT m HawkSpec
 parseArgs [] = return Help
 parseArgs args = runOptionParserT options parser args
   where
@@ -216,7 +216,7 @@ parseArgs args = runOptionParserT options parser args
             , (Option.Map,     map')
             ]
 
-    help, version, eval, apply, map' :: (Functor m,MonadIO m) => CommonSeparators
+    help, version, eval, apply, map' :: (MonadIO m) => CommonSeparators
                                      -> OptionParserT HawkOption m HawkSpec
     help    _ = return Help
     version _ = return Version

--- a/src/System/Console/Hawk/Runtime/HaskellExpr.hs
+++ b/src/System/Console/Hawk/Runtime/HaskellExpr.hs
@@ -4,13 +4,12 @@ module System.Console.Hawk.Runtime.HaskellExpr where
 
 import qualified Data.ByteString.Lazy.Char8 as B
 
-import Data.HaskellExpr
-import System.Console.Hawk.Representable
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.Base
+import           Data.HaskellExpr
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.Base
 
 
-eSomeRows :: Rows a => HaskellExpr (a -> SomeRows)
+eSomeRows :: HaskellExpr (a -> SomeRows)
 eSomeRows = qualified "System.Console.Hawk.Runtime" "SomeRows"
 
 eProcessTable :: HaskellExpr (HawkRuntime -> ([[B.ByteString]] -> SomeRows) -> HawkIO ())

--- a/src/System/Console/Hawk/Sandbox.hs
+++ b/src/System/Console/Hawk/Sandbox.hs
@@ -13,37 +13,36 @@
 --   limitations under the License.
 
 -- Extra steps to be performed if hawk was installed from a sandbox.
--- 
+--
 -- Extra steps are needed because the hawk binary needs runtime access
 -- to the hawk library, but the hint library only knows about the globally-
 -- installed libraries. If hawk has been installed with a sandbox, its
 -- binary and its library will be installed in a local folder instead of
 -- in the global location.
-{-# LANGUAGE TemplateHaskell, TupleSections #-}
+{-# LANGUAGE TemplateHaskell, TupleSections   #-}
 module System.Console.Hawk.Sandbox
     ( extraGhcArgs
     , runHawkInterpreter
     ) where
 
-import Control.Applicative
-import Control.Monad
-import Data.List.Extra (wordsBy)
-import Data.Maybe
-import Language.Haskell.Interpreter (InterpreterT, InterpreterError)
-import Language.Haskell.Interpreter.Unsafe (unsafeRunInterpreterWithArgs)
-import Language.Haskell.TH.Syntax (lift, runIO)
-import System.Directory.PathFinder
-import System.Environment (getEnvironment)
-import System.FilePath ((</>))
-import Text.Printf (printf)
+import           Control.Monad
+import           Data.List.Extra (wordsBy)
+import           Data.Maybe
+import           Language.Haskell.Interpreter (InterpreterError, InterpreterT)
+import           Language.Haskell.Interpreter.Unsafe (unsafeRunInterpreterWithArgs)
+import           Language.Haskell.TH.Syntax (lift, runIO)
+import           System.Directory.PathFinder
+import           System.Environment (getEnvironment)
+import           System.FilePath ((</>))
+import           Text.Printf (printf)
 
 -- magic self-referential module created by cabal
-import Paths_haskell_awk (getBinDir)
+import           Paths_haskell_awk (getBinDir)
 
 
 data Sandbox = Sandbox
   { sandboxPathFinder :: PathFinder
-  , packageDbFinder :: MultiPathFinder
+  , packageDbFinder   :: MultiPathFinder
   }
 
 dotCabal :: Sandbox
@@ -119,10 +118,10 @@ extraGhcArgs = fmap (printf "-package-db %s") <$> detectPackageDbs
 
 -- | a version of runInterpreter which can load libraries
 --   installed along hawk's sandbox folder, if applicable.
--- 
+--
 -- Must be called inside a `withLock` block, otherwise hint will generate
 -- conflicting temporary files.
--- 
+--
 -- TODO: Didn't we write a patch for hint about this?
 --       Do we still need the lock?
 runHawkInterpreter :: InterpreterT IO a -> IO (Either InterpreterError a)

--- a/src/System/Console/Hawk/UserExpr/CanonicalExpr.hs
+++ b/src/System/Console/Hawk/UserExpr/CanonicalExpr.hs
@@ -3,15 +3,14 @@ module System.Console.Hawk.UserExpr.CanonicalExpr where
 
 import qualified Data.ByteString.Lazy.Char8 as B
 
-import Control.Applicative
-import Data.HaskellExpr
-import Data.HaskellExpr.Base
-import System.Console.Hawk.Args
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.Base
-import System.Console.Hawk.Runtime.HaskellExpr
-import System.Console.Hawk.UserExpr.InputReadyExpr
-import System.Console.Hawk.UserExpr.OriginalExpr
+import           Data.HaskellExpr
+import           Data.HaskellExpr.Base
+import           System.Console.Hawk.Args
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.Base
+import           System.Console.Hawk.Runtime.HaskellExpr
+import           System.Console.Hawk.UserExpr.InputReadyExpr
+import           System.Console.Hawk.UserExpr.OriginalExpr
 
 
 -- | Regardless of the requested input format, we currently convert all user expressions

--- a/src/System/Console/Hawk/UserExpr/InputReadyExpr.hs
+++ b/src/System/Console/Hawk/UserExpr/InputReadyExpr.hs
@@ -3,12 +3,11 @@ module System.Console.Hawk.UserExpr.InputReadyExpr where
 
 import qualified Data.ByteString.Lazy.Char8 as B
 
-import Control.Applicative
-import Data.HaskellExpr
-import Data.HaskellExpr.Base
-import System.Console.Hawk.Runtime
-import System.Console.Hawk.Runtime.HaskellExpr
-import System.Console.Hawk.UserExpr.OriginalExpr
+import           Data.HaskellExpr
+import           Data.HaskellExpr.Base
+import           System.Console.Hawk.Runtime
+import           System.Console.Hawk.Runtime.HaskellExpr
+import           System.Console.Hawk.UserExpr.OriginalExpr
 
 
 -- | While the original user input may describe a value or a function on a

--- a/src/System/Console/Hawk/UserPrelude.hs
+++ b/src/System/Console/Hawk/UserPrelude.hs
@@ -1,15 +1,14 @@
 -- | In which the user prelude is massaged into the form hint needs.
 module System.Console.Hawk.UserPrelude where
 
-import Control.Applicative
-import Control.Monad.Trans.Class
-import Data.ByteString as B
-import Text.Printf
+import           Control.Monad.Trans.Class
+import           Data.ByteString as B
+import           Text.Printf
 
-import Control.Monad.Trans.Uncertain
-import Data.HaskellModule
-import System.Console.Hawk.Sandbox
-import System.Console.Hawk.UserPrelude.Extend
+import           Control.Monad.Trans.Uncertain
+import           Data.HaskellModule
+import           System.Console.Hawk.Sandbox
+import           System.Console.Hawk.UserPrelude.Extend
 
 
 type UserPrelude = HaskellModule
@@ -29,7 +28,7 @@ testC f = do
 -- import Prelude
 -- import qualified Data.ByteString.Lazy.Char8 as B
 -- import qualified Data.List as L
--- 
+--
 -- >>> testC "moduleName"
 -- module MyPrelude where
 -- import Prelude

--- a/src/System/Directory/PathFinder.hs
+++ b/src/System/Directory/PathFinder.hs
@@ -12,8 +12,6 @@ import Data.List
 import System.Directory
 import System.FilePath
 
-import System.Directory.Extra
-
 
 type PathFinder = StateT FilePath (MaybeT IO) ()
 type MultiPathFinder = StateT FilePath (ListT IO) ()

--- a/tests/RunTests.hs
+++ b/tests/RunTests.hs
@@ -12,16 +12,15 @@
 --   See the License for the specific language governing permissions and
 --   limitations under the License.
 
-import Control.Applicative
-import Data.List
+import           Data.List
 import qualified System.Console.Hawk.Representable.Test as ReprTest
 import qualified System.Console.Hawk.Test as HawkTest
-import System.FilePath
-import System.Environment
-import Text.Printf
+import           System.Environment
+import           System.FilePath
+import           Text.Printf
 
-import Test.DocTest (doctest)
-import Test.Hspec (hspec)
+import           Test.DocTest (doctest)
+import           Test.Hspec (hspec)
 
 
 substSuffix :: Eq a => [a] -> [a] -> [a] -> [a]
@@ -34,15 +33,15 @@ substSuffix _ _ xs = xs
 doctest' :: String -> IO ()
 doctest' file = do
     exePath <- dropExtension <$> getExecutablePath
-    
+
     let srcPath = "src"
     let autogenPath = substSuffix ("reference" </> "reference")
                                   "autogen"
                                   exePath
-    
+
     let includeSrc      = printf "-i%s" srcPath
     let includeAutogen  = printf "-i%s" autogenPath
-    
+
     doctest [includeSrc, includeAutogen, file]
 
 main :: IO ()


### PR DESCRIPTION
Addressed almost all compiler warnings.

There are a few left in src/Control/Monad/Trans/Uncertain.hs:

``` log
src/Control/Monad/Trans/Uncertain.hs:7:1: warning: [-Wdeprecations]
    Module ‘Control.Monad.Trans.Error’ is deprecated:
      Use Control.Monad.Trans.Except instead

src/Control/Monad/Trans/Uncertain.hs:18:21: warning: [-Wdeprecations]
    In the use of type constructor or class ‘ErrorT’
    (imported from Control.Monad.Trans.Error):
    Deprecated: "Use Control.Monad.Trans.Except instead"

src/Control/Monad/Trans/Uncertain.hs:82:33: warning: [-Wdeprecations]
    In the use of ‘mapErrorT’
    (imported from Control.Monad.Trans.Error):
    Deprecated: "Use Control.Monad.Trans.Except instead"

src/Control/Monad/Trans/Uncertain.hs:85:30: warning: [-Wdeprecations]
    In the use of ‘runErrorT’
    (imported from Control.Monad.Trans.Error):
    Deprecated: "Use Control.Monad.Trans.Except instead"
```

I am not qualified to address them.
These warnings show up repeatedly when running the test suite.
