### PR TITLE
Fix hlint hints

### DIFF
--- a/runtime/System/Console/Hawk/Representable.hs
+++ b/runtime/System/Console/Hawk/Representable.hs
@@ -66,7 +66,7 @@ instance ListAsRow Char where
     listRepr' _ = C8.pack
 
 instance ListAsRow ByteString where
-    listRepr' d = C8.intercalate d
+    listRepr' = C8.intercalate
 
 instance (Row a, Row b) => ListAsRow (Map a b) where
     listRepr' d = listRepr' d . L.map (listRepr' d . M.toList)

--- a/runtime/System/Console/Hawk/Runtime.hs
+++ b/runtime/System/Console/Hawk/Runtime.hs
@@ -81,16 +81,16 @@ outputRows (OutputSpec _ spec) x = ignoringBrokenPipe $ do
   where
     join' = join (B.fromStrict $ recordDelimiter spec)
     toRows = repr (B.fromStrict $ fieldDelimiter spec)
-    
+
     join :: B.ByteString -> [B.ByteString] -> B.ByteString
     join "\n" = B.unlines
     join sep  = B.intercalate sep
 
 -- Don't fret if stdout is closed early, that is the way of shell pipelines.
 ignoringBrokenPipe :: IO () -> IO ()
-ignoringBrokenPipe = handleJust isBrokenPipe $ \_ -> do
+ignoringBrokenPipe = handleJust isBrokenPipe $ \_ ->
     -- ignore the broken pipe
     return ()
   where
     isBrokenPipe e | ioe_type e == ResourceVanished = Just e
-    isBrokenPipe _ | otherwise                      = Nothing
+    isBrokenPipe _                                  = Nothing

--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -16,7 +16,7 @@ import Text.Printf
 import Control.Monad.Trans.Uncertain
 
 -- $setup
--- 
+--
 -- >>> :{
 -- let testH tp = do { putStrLn "Usage: more [option]... <song.mp3>"
 --                   ; putStr $ optionsHelpWith head
@@ -26,7 +26,7 @@ import Control.Monad.Trans.Uncertain
 --                                              ["cowbell","guitar","saxophone"]
 --                   }
 -- :}
--- 
+--
 -- >>> let testP args tp p = runUncertain $ runOptionParserWith head id (const [""]) tp ["cowbell","guitar","saxophone"] p args
 
 
@@ -41,7 +41,7 @@ class Eq a => Option a where
 -- | The type of the argument set by the option. Since Haskell doesn't support
 --   dependent types, this is just a string description of the type, plus extra
 --   support for boolean flags and optional arguments.
--- 
+--
 -- To maintain the illusion of precise types, please use combining functions
 -- such as `nullable int` instead.
 data OptionType
@@ -118,21 +118,21 @@ optionsHelp :: Option o => [o] -> String
 optionsHelp = optionsHelpWith shortName longName helpMsg optionType
 
 -- | A version of `optionsHelp` which doesn't use the Option typeclass.
--- 
+--
 -- >>> :{
 -- let { tp "cowbell"   = flag
 --     ; tp "guitar"    = string
 --     ; tp "saxophone" = nullable int
 --     }
 -- :}
--- 
+--
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
 -- Options:
 --   -c       --cowbell          adds more cowbell.
 --   -g str   --guitar=str       adds more guitar.
 --   -s[int]  --saxophone[=int]  adds more saxophone.
--- 
+--
 optionsHelpWith :: (o -> Char)
                 -> (o -> String)
                 -> (o -> [String])
@@ -156,7 +156,7 @@ runOptionParserT :: (Option o, Monad m)
 runOptionParserT = runOptionParserWith shortName longName helpMsg optionType
 
 -- | A version of `runOptionParserT` which doesn't use the Option typeclass.
--- 
+--
 -- >>> :{
 -- testP ["--cowbell","-s"] (const flag) $ do
 --   { c <- consumeLast "cowbell"   False consumeFlag
@@ -195,7 +195,7 @@ runOptionParserWith shortName' longName' helpMsg' optionType'
 
 
 -- | Try to parse a setting of a particular type.
--- 
+--
 -- The input will never be Nothing unless the optionType is nullable, and even
 -- then consumeNullable will get rid of it for you. Yet we still need the type
 -- of the input to be `Maybe String` in order for consumeNullable itself to be
@@ -204,7 +204,7 @@ type OptionConsumer m a = Maybe String -> UncertainT m a
 
 
 -- | Specifies that the option cannot be assigned a value.
--- 
+--
 -- >>> let tp = const flag
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -216,13 +216,13 @@ flag :: OptionType
 flag = Flag
 
 -- | True if the given flag appears.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consumeCowbell = consumeLast "cowbell" False consumeFlag :: OptionParser String Bool
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- True
--- 
+--
 -- >>> testP ["--saxophone"] tp consumeCowbell
 -- False
 consumeFlag :: Monad m => OptionConsumer m Bool
@@ -230,7 +230,7 @@ consumeFlag _ = return True
 
 
 -- | Specifies that the option must be assigned a String value.
--- 
+--
 -- >>> let tp = const string
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -242,19 +242,19 @@ string :: OptionType
 string = Setting "str"
 
 -- | The value assigned to the option, interpreted as a string.
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" consumeString :: OptionParser String String
--- 
+--
 -- >>> testP ["--cowbell", "extra"] tp consumeCowbell
 -- "extra"
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- "s"
--- 
+--
 -- >>> testP [] tp consumeCowbell
 -- "<none>"
--- 
+--
 -- >>> testP ["-c"] tp consumeCowbell
 -- error: option `-c' requires an argument str
 -- *** Exception: ExitFailure 1
@@ -264,7 +264,7 @@ consumeString Nothing = error "please use consumeNullable to consume nullable op
 
 
 -- | Specifies that the value of the option may be omitted.
--- 
+--
 -- >>> let tp = const (nullable string)
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
@@ -279,19 +279,19 @@ nullable Flag = error "nullable flag doesn't make sense"
 
 -- | The value assigned to an option, or a default value if no value was
 --   assigned. Must be used to consume `nullable` options.
--- 
+--
 -- >>> let tp = const (nullable string)
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" $ consumeNullable "<default>" consumeString :: OptionParser String String
--- 
+--
 -- >>> testP ["-cs"] tp consumeCowbell
 -- "s"
--- 
+--
 -- >>> testP ["-c", "-s"] tp consumeCowbell
 -- "<default>"
--- 
+--
 -- >>> testP ["-s"] tp consumeCowbell
 -- "<none>"
--- 
+--
 -- >>> testP ["-c"] tp $ consumeLast "cowbell" "<none>" consumeString
 -- *** Exception: please use consumeNullable to consume nullable options
 consumeNullable :: Monad m => a -> OptionConsumer m a -> OptionConsumer m a
@@ -300,14 +300,14 @@ consumeNullable _ consume o = consume o
 
 
 -- | A helper for defining custom options types.
--- 
+--
 -- >>> :{
 -- let { tp "cowbell"   = readable "amount"
 --     ; tp "guitar"    = readable "file"
 --     ; tp "saxophone" = readable "weight"
 --     }
 -- :}
--- 
+--
 -- >>> testH tp
 -- Usage: more [option]... <song.mp3>
 -- Options:
@@ -318,13 +318,13 @@ readable :: String -> OptionType
 readable = Setting
 
 -- | The value assigned to the option, interpreted by `read`.
--- 
+--
 -- >>> let tp = const (readable "unit")
 -- >>> let consumeCowbell = consumeLast "cowbell" () consumeReadable :: OptionParser String ()
--- 
+--
 -- >>> testP ["--cowbell=()"] tp consumeCowbell >>= print
 -- ()
--- 
+--
 -- >>> testP ["--cowbell=foo"] tp consumeCowbell >>= print
 -- error: "foo" is not a valid value for this option.
 -- *** Exception: ExitFailure 1
@@ -337,19 +337,19 @@ consumeReadable o = do
 
 
 -- | Users are encouraged to create custom option types, like this.
--- 
+--
 -- (see the source)
 int :: OptionType
 int = readable "int"
 
 -- | The value assigned to the option, interpreted as an int.
--- 
+--
 -- This is a good example of how to consume custom option types.
 -- (see the source)
--- 
+--
 -- >>> let tp = const int
 -- >>> let consumeCowbell = consumeLast "cowbell" (-1) consumeInt :: OptionParser String Int
--- 
+--
 -- >>> testP ["--cowbell=42"] tp consumeCowbell
 -- 42
 consumeInt :: Monad m => OptionConsumer m Int
@@ -386,17 +386,17 @@ filePath = Setting "path"
 -- *** Exception: ExitFailure 1
 consumeFilePath :: MonadIO m
                 => (FilePath -> UncertainT m FilePath) -> OptionConsumer m String
-consumeFilePath check input = consumeString input >>= check >>= return
+consumeFilePath check input = consumeString input >>= check
 
 
 -- | All the occurences of a given option.
--- 
+--
 -- It is an error to consume the same value twice (we currently return an
 -- empty list).
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeAll "cowbell" consumeString :: OptionParser String [String]
--- 
+--
 -- >>> :{
 -- testP ["--cowbell=foo", "--cowbell", "bar"] tp $ do
 --   { xs <- consumeCowbell
@@ -413,13 +413,13 @@ consumeAll o consume = OptionParserT $ do
 
 -- | The last occurence of a given option, or a default value if the option
 --   isn't specified.
--- 
+--
 -- It is an error to consume the same value twice (we currently return the
 -- default value).
--- 
+--
 -- >>> let tp = const string
 -- >>> let consumeCowbell = consumeLast "cowbell" "<none>" consumeString :: OptionParser String String
--- 
+--
 -- >>> :{
 -- testP ["--cowbell=foo", "--cowbell", "bar"] tp $ do
 --   { xs <- consumeCowbell
@@ -441,16 +441,16 @@ consumeExclusive :: (Option o, Functor m, Monad m)
 consumeExclusive = consumeExclusiveWith longName
 
 -- | A version of `consumeExclusive` which doesn't use the Option typeclass.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExclusiveWith id [("cowbell",0),("guitar",1),("saxophone",2)] (-1) :: OptionParser String Int
--- 
+--
 -- >>> testP ["-s"] tp consume
 -- 2
--- 
+--
 -- >>> testP [] tp consume
 -- -1
--- 
+--
 -- >>> testP ["-cs"] tp consume
 -- error: cowbell and saxophone are incompatible
 -- *** Exception: ExitFailure 1
@@ -471,16 +471,16 @@ consumeExclusiveWith longName' assoc defaultValue = do
 
 
 -- | The next non-option argument.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExtra consumeString :: OptionParser String (Maybe String)
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp consume
 -- Just "song.mp3"
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume)
 -- Just "jazz.mp3"
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume >> consume)
 -- Nothing
 consumeExtra :: (Functor m, Monad m)
@@ -494,16 +494,16 @@ consumeExtra consume = OptionParserT $ do
         fmap Just $ lift . lift $ consume $ Just x
 
 -- | All remaining non-option arguments.
--- 
+--
 -- >>> let tp = const flag
 -- >>> let consume = consumeExtras consumeString :: OptionParser String [String]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp consume
 -- ["song.mp3","jazz.mp3"]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consumeExtra consumeString >> consume)
 -- ["jazz.mp3"]
--- 
+--
 -- >>> testP ["-cs", "song.mp3", "jazz.mp3"] tp (consume >> consume)
 -- []
 consumeExtras :: (Functor m, Monad m)

--- a/src/Control/Monad/Trans/Uncertain.hs
+++ b/src/Control/Monad/Trans/Uncertain.hs
@@ -50,7 +50,7 @@ fromRightM (Right x) = return x
 
 
 multilineMsg :: String -> String
-multilineMsg = concat . map (printf "\n  %s") . lines
+multilineMsg = concatMap (printf "\n  %s") . lines
 
 -- | Indent a multiline warning message.
 -- >>> :{
@@ -58,7 +58,7 @@ multilineMsg = concat . map (printf "\n  %s") . lines
 --   multilineWarn "foo\nbar\n"
 --   return 42
 -- :}
--- warning: 
+-- warning:
 --   foo
 --   bar
 -- 42
@@ -71,7 +71,7 @@ multilineWarn = warn . multilineMsg
 --   multilineFail "foo\nbar\n"
 --   return 42
 -- :}
--- error: 
+-- error:
 --   foo
 --   bar
 -- *** Exception: ExitFailure 1
@@ -92,9 +92,9 @@ uncertainT (Right x, warnings) = mapM_ warn warnings >> return x
 
 -- | A version of `runWarnings` which allows you to interleave IO actions
 --   with uncertain actions.
--- 
+--
 -- Note that the warnings are displayed after the IO's output.
--- 
+--
 -- >>> :{
 -- runWarningsIO $ do
 --   warn "before"
@@ -106,7 +106,7 @@ uncertainT (Right x, warnings) = mapM_ warn warnings >> return x
 -- warning: before
 -- warning: after
 -- Right 42
--- 
+--
 -- >>> :{
 -- runWarningsIO $ do
 --   warn "before"
@@ -125,7 +125,7 @@ runWarningsIO u = do
 
 -- | A version of `runUncertain` which only prints the warnings, not the
 --   errors. Unlike `runUncertain`, it doesn't terminate on error.
--- 
+--
 -- >>> :{
 -- runWarnings $ do
 --   warn "before"
@@ -135,7 +135,7 @@ runWarningsIO u = do
 -- warning: before
 -- warning: after
 -- Right 42
--- 
+--
 -- >>> :{
 -- runWarnings $ do
 --   warn "before"
@@ -150,9 +150,9 @@ runWarnings = runWarningsIO . mapUncertainT (return . runIdentity)
 
 -- | A version of `runUncertain` which allows you to interleave IO actions
 --   with uncertain actions.
--- 
+--
 -- Note that the warnings are displayed after the IO's output.
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "before"
@@ -164,7 +164,7 @@ runWarnings = runWarningsIO . mapUncertainT (return . runIdentity)
 -- warning: before
 -- warning: after
 -- 42
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "before"
@@ -186,9 +186,9 @@ runUncertainIO u = do
       Right x -> return x
 
 -- | Print warnings and errors, terminating on error.
--- 
+--
 -- Note that the warnings are displayed even if there is also an error.
--- 
+--
 -- >>> :{
 -- runUncertainIO $ do
 --   warn "first"
@@ -206,7 +206,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 
 -- | Upgrade an `IO a -> IO a` wrapping function into a variant which uses
 --   `UncertainT IO` instead of `IO`.
--- 
+--
 -- >>> :{
 -- let wrap body = do { putStrLn "before"
 --                    ; r <- body
@@ -214,7 +214,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 --                    ; return r
 --                    }
 -- :}
--- 
+--
 -- >>> :{
 -- wrap $ do { putStrLn "hello"
 --           ; return 42
@@ -224,7 +224,7 @@ runUncertain = runUncertainIO . mapUncertainT (return . runIdentity)
 -- hello
 -- after
 -- 42
--- 
+--
 -- >>> :{
 -- runUncertainIO $ wrapUncertain wrap
 --                $ do { lift $ putStrLn "hello"
@@ -247,7 +247,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 
 -- | A version of `wrapUncertain` for wrapping functions of type
 --   `(Handle -> IO a) -> IO a`.
--- 
+--
 -- >>> :{
 -- let wrap body = do { putStrLn "before"
 --                    ; r <- body 42
@@ -255,7 +255,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 --                    ; return r
 --                    }
 -- :}
--- 
+--
 -- >>> :{
 -- wrap $ \x -> do { putStrLn "hello"
 --                 ; return (x + 1)
@@ -265,7 +265,7 @@ wrapUncertain wrap body = wrapUncertainArg wrap' body'
 -- hello
 -- after
 -- 43
--- 
+--
 -- >>> :{
 -- runUncertainIO $ wrapUncertainArg wrap
 --                $ \x -> do { lift $ putStrLn "hello"
@@ -283,7 +283,7 @@ wrapUncertainArg :: (Monad m, Monad m')
                  -> ((v -> UncertainT m b) -> UncertainT m' b)
 wrapUncertainArg wrap body = do
     (r, ws) <- lift $ wrap $ runUncertainT . body
-    
+
     -- repackage the warnings and errors
     mapM_ warn ws
     fromRightM r

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE PackageImports #-}
 -- | A generic caching interface.
--- 
+--
 -- The intent is to support many concrete implementations,
 -- and to use specify caching policies using combinators.
--- 
+--
 -- Note that even though we _support_ many concrete implementations,
 -- for simplicity we only provide one based on an association-list.
 module Data.Cache where
@@ -47,9 +47,9 @@ cached c k computeSlowly = do
 
 
 -- | A dummy cache which never caches anything.
--- 
+--
 -- Semantically equivalent to `finiteCache 0 $ assocCache`, except for the `m`.
--- 
+--
 -- >>> withNullCache testC
 -- one
 -- two
@@ -71,7 +71,7 @@ withNullCache body = body nullCache
 
 
 -- | A very inefficient example implementation.
--- 
+--
 -- >>> withAssocCache testC
 -- one
 -- two
@@ -97,14 +97,14 @@ withAssocCache body = evalStateT (body assocCache) []
 
 -- | Only cache the first `n` requests (use n=-1 for unlimited).
 --   Combine with a cache policy in order to reuse those `n` slots.
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 2 $ testC
 -- one
 -- two
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 1 $ testC
 -- one
 -- two
@@ -112,7 +112,7 @@ withAssocCache body = evalStateT (body assocCache) []
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 0 $ testC
 -- one
 -- two
@@ -121,7 +121,7 @@ withAssocCache body = evalStateT (body assocCache) []
 -- testing
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache (-1) $ testC
 -- one
 -- two
@@ -154,13 +154,13 @@ withFiniteCache n body c = evalStateT (body $ finiteCache n c) 0
 
 
 -- | An example cache-policy implementation: Least-Recently-Used.
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 2 $ withLruCache testC
 -- one
 -- two
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 1 $ withLruCache testC
 -- one
 -- two
@@ -168,7 +168,7 @@ withFiniteCache n body c = evalStateT (body $ finiteCache n c) 0
 -- two
 -- testing
 -- [3,3,3,3,7,7]
--- 
+--
 -- >>> withAssocCache $ withFiniteCache 0 $ withLruCache testC
 -- one
 -- two
@@ -204,9 +204,9 @@ lruCache c = Cache
           [] -> do
             -- the cache is both full and empty? try to reset.
             lift $ clearCache c
-    
+
     write  k = modify (k:)
-    remove k = modify $ filter $ (/= k)
+    remove k = modify $ filter (/= k)
 
 withLruCache :: (Monad m, Eq k)
              => (Cache (StateT [k] m) k v -> StateT [k] m a)
@@ -215,9 +215,9 @@ withLruCache body c = evalStateT (body $ lruCache c) []
 
 
 -- | An extreme version of the LRU strategy.
--- 
+--
 -- Semantically equivalent to `lruCache . finiteCache 1`, except for the `m`.
--- 
+--
 -- >>> withAssocCache $ withSingletonCache testC
 -- one
 -- two

--- a/src/Data/HaskellModule/Parse.hs
+++ b/src/Data/HaskellModule/Parse.hs
@@ -19,24 +19,24 @@ locatedExtensions = fmap go . located
   where
     go :: [ModulePragma] -> [ExtensionName]
     go = concatMap extNames
-    
+
     extNames :: ModulePragma -> [ExtensionName]
     extNames (LanguagePragma _ exts) = map prettyPrint exts
-    extNames (OptionsPragma _ _ _) = []  -- TODO: accept "-XExtName"
-    extNames _ = []
+    extNames  OptionsPragma{}        = []  -- TODO: accept "-XExtName"
+    extNames _                       = []
 
 locatedImports :: [ImportDecl] -> Located [QualifiedModule]
 locatedImports = fmap go . located
   where
     go :: [ImportDecl] -> [QualifiedModule]
     go = map qualify
-    
+
     qualify :: ImportDecl -> QualifiedModule
     qualify decl = (fullName decl, qualifiedName decl)
-    
+
     fullName :: ImportDecl -> String
     fullName = prettyPrint . importModule
-    
+
     qualifiedName :: ImportDecl -> Maybe String
     qualifiedName = fmap prettyPrint . importAs
 
@@ -48,7 +48,7 @@ locatedModule srcLoc source (ModuleName mName) = case moduleLine of
     isModuleDecl :: Either B.ByteString String -> Bool
     isModuleDecl (Left xs) = "module " `B.isPrefixOf` xs
     isModuleDecl (Right xs) = "module " `isPrefixOf` xs
-    
+
     moduleLine :: Maybe Int
     moduleLine = fmap index2line $ findIndex isModuleDecl source
 
@@ -60,10 +60,10 @@ index2line = (+ 1)
 
 
 -- | A variant of `splitAt` which makes it easy to make `snd` empty.
--- 
+--
 -- >>> maybeSplitAt Nothing "abc"
 -- ("abc","")
--- 
+--
 -- >>> maybeSplitAt (Just 0) "abc"
 -- ("","abc")
 maybeSplitAt :: Maybe Int -> [a] -> ([a], [a])
@@ -72,31 +72,31 @@ maybeSplitAt (Just i) ys = splitAt i ys
 
 -- | Given n ordered indices before which to split, split the list into n+1 pieces.
 --   Omitted indices will produce empty pieces.
--- 
+--
 -- >>> multiSplit [] "foo"
 -- ["foo"]
--- 
+--
 -- >>> multiSplit [Just 0, Just 1, Just 2] "foo"
 -- ["","f","o","o"]
--- 
+--
 -- >>> multiSplit [Just 0, Just 1, Nothing] "foo"
 -- ["","f","oo",""]
--- 
+--
 -- >>> multiSplit [Just 0, Nothing, Just 2] "foo"
 -- ["","fo","","o"]
--- 
+--
 -- >>> multiSplit [Just 0, Nothing, Nothing] "foo"
 -- ["","foo","",""]
--- 
+--
 -- >>> multiSplit [Nothing, Just 1, Just 2] "foo"
 -- ["f","","o","o"]
--- 
+--
 -- >>> multiSplit [Nothing, Just 1, Nothing] "foo"
 -- ["f","","oo",""]
--- 
+--
 -- >>> multiSplit [Nothing, Nothing, Just 2] "foo"
 -- ["fo","","","o"]
--- 
+--
 -- >>> multiSplit [Nothing, Nothing, Nothing] "foo"
 -- ["foo","","",""]
 multiSplit :: [Maybe Int] -> [a] -> [[a]]
@@ -114,10 +114,10 @@ splitSource = multiSplit . (fmap . fmap) (line2index . srcLine)
 
 -- Due to a limitation of haskell-parse-exts, there is no `parseModule`
 -- variant of `readModule` which would parse from a String instead of a file.
--- 
+--
 -- According to the documentation [1], only `parseFile` honors language
 -- pragmas, without which PackageImport-style imports will fail to parse.
--- 
+--
 -- [1] http://hackage.haskell.org/package/haskell-src-exts-1.14.0.1/docs/Language-Haskell-Exts-Parser.html#t:ParseMode
 
 readModule :: FilePath -> UncertainT IO HaskellModule
@@ -138,6 +138,6 @@ readModule f = do
         (moduleName,      moduleLoc) = runLocated (locatedModule srcLoc source moduleDecl)
         (importedModules, importLoc) = runLocated (locatedImports imports)
         (_,                 declLoc) = runLocated (located decls)
-        
+
         sourceParts = splitSource [moduleLoc, importLoc, declLoc] source
         [pragmaSource, moduleSource, importSource, codeSource] = sourceParts

--- a/src/System/Console/Hawk/Context/Dir.hs
+++ b/src/System/Console/Hawk/Context/Dir.hs
@@ -36,7 +36,7 @@ findContext startDir =
   where
     mkHawkPath = (</> ".hawk")
     possibleContextDirs = map mkHawkPath (ancestors startDir)
-    
+
     validDirOrNothing dir = do
       dirExists <- doesDirectoryExist dir
       if dirExists
@@ -80,10 +80,10 @@ checkContextDir dir = do
     if dirExists
       then do
         permissions <- liftIO $ getPermissions dir
-        when (not $ writable permissions) $ fail $ concat [
+        unless (writable permissions) $ fail $ concat [
            "cannot use '",dir,"' as context directory because it is not "
           ,"writable"]
-        when (not $ searchable permissions) $ fail $ concat [
+        unless (searchable permissions) $ fail $ concat [
            "cannot use '",dir,"' as context directory because it is not "
           ,"searchable"]
         return False
@@ -92,10 +92,10 @@ checkContextDir dir = do
         -- and searchable
         let parent = case takeDirectory dir of {"" -> ".";p -> p}
         permissions <- liftIO $ getPermissions parent
-        when (not $ writable permissions) $ fail $ concat[
+        unless (writable permissions) $ fail $ concat[
            "cannot create context directory '",dir,"' because the parent "
           ," directory is not writable (",show permissions,")"]
-        when (not $ searchable permissions) $ fail $ concat[
+        unless (searchable permissions) $ fail $ concat[
            "cannot create context directory '",dir,"' because the parent "
           ," directory is not searchable (",show permissions,")"]
         warn $ concat ["directory '",dir,"' doesn't exist, creating a "


### PR DESCRIPTION
Decided to only address a few hlint hints.

There are 3 hints in runtime/, corrected 2 of them, left the one about a redundant do.

There are 9 hints in tests/, mostly redundant do and redundant brackets.
Left them out entirely.

Of the 33 hints in src/, I addressed 8 small ones.
