### PR TITLE
Use stack everywhere, fixes #132, #166, #157, and #158

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
-dist
-cabal-dev
-*.o
-*.hi
-*.chi
-*.chs.h
-*.swp
-*.swo
-.virthualenv
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,104 +1,40 @@
-# NB: don't set `language: haskell` here
+# This is the simple Travis configuration, which is intended for use
+# on applications which do not require cross-platform and
+# multiple-GHC-version support. For more information and other
+# options, see:
+#
+# https://docs.haskellstack.org/en/stable/travis_ci/
+#
+# Copy these contents into the root directory of your Github project in a file
+# named .travis.yml
 
-# See also https://github.com/hvr/multi-ghc-travis for more information
+# Use new container infrastructure to enable caching
+sudo: false
 
-# The following lines enable several GHC versions and/or HP versions
-# to be tested; often it's enough to test only against the last
-# release of a major GHC version. Setting HPVER implictly sets
-# GHCVER. Omit lines with versions you don't need/want testing for.
-env:
-# - GHCVER=6.12.3
-# - GHCVER=7.0.1
-# - GHCVER=7.0.2
-# - GHCVER=7.0.3
-# - GHCVER=7.0.4
-# - GHCVER=7.2.1
-# - GHCVER=7.2.2
-# - GHCVER=7.4.1
-# - GHCVER=7.4.2
-# - GHCVER=7.6.1
- - GHCVER=7.6.2
- - GHCVER=7.6.3
-# - GHCVER=7.8.1
- - GHCVER=7.8.2
- - GHCVER=7.8.3
-# - HPVER=2011.4.0.0
-# - HPVER=2012.2.0.0
-# - HPVER=2012.4.0.0
-- HPVER=2013.2.0.0
-- HPVER=2014.2.0.0
- - GHCVER=head
+# Do not choose a language; we provide our own build tools.
+language: generic
 
-# Note: the distinction between `before_install` and `install` is not
-#       important.
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack
+
+# Ensure necessary system libraries are present
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
 before_install:
- - case "$HPVER" in
-    "") ;;
-
-    "2013.2.0.0")
-      export GHCVER=7.6.3 ;
-      echo "constraints:async==2.0.1.4,attoparsec==0.10.4.0,case-insensitive==1.0.0.1,cgi==3001.1.7.5,fgl==5.4.2.4,GLUT==2.4.0.0,GLURaw==1.3.0.0,haskell-src==1.0.1.5,hashable==1.1.2.5,html==1.0.1.2,HTTP==4000.2.8,HUnit==1.2.5.2,mtl==2.1.2,network==2.4.1.2,OpenGL==2.8.0.0,OpenGLRaw==1.3.0.0,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.6,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.2,stm==2.4.2,syb==0.4.0,text==0.11.3.1,transformers==0.3.0.0,unordered-containers==0.2.3.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.1" > cabal.config ;;
-
-    "2012.4.0.0")
-      export GHCVER=7.6.2 ;
-      echo "constraints:async==2.0.1.3,cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.5,HUnit==1.2.5.1,mtl==2.1.2,network==2.3.1.0,OpenGL==2.2.3.1,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.5.1.1,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.1.1,stm==2.4,syb==0.3.7,text==0.11.2.3,transformers==0.3.0.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.0" > cabal.config ;;
-
-    "2012.2.0.0")
-      export GHCVER=7.4.1 ;
-      echo "constraints:cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.3,HUnit==1.2.4.2,mtl==2.1.1,network==2.3.0.13,OpenGL==2.2.3.1,parallel==3.2.0.2,parsec==3.1.2,QuickCheck==2.4.2,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.1,stm==2.3,syb==0.3.6.1,text==0.11.2.0,transformers==0.3.0.0,xhtml==3000.2.1,zlib==0.5.3.3" > cabal.config ;;
-
-    "2011.4.0.0")
-      export GHCVER=7.0.4 ;
-      echo "constraints:cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.4,html==1.0.1.2,HUnit==1.2.4.2,network==2.3.0.5,OpenGL==2.2.3.0,parallel==3.1.0.1,parsec==3.1.1,QuickCheck==2.4.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.1,stm==2.2.0.1,syb==0.3.3,xhtml==3000.2.0.4,zlib==0.5.3.1,HTTP==4000.1.2,deepseq==1.1.0.2" > cabal.config ;;
-
-    *)
-      export GHCVER=unknown ;
-      echo "unknown/invalid Haskell Platform requested" ;
-      exit 1 ;;
-
-   esac
-
- - sudo add-apt-repository -y ppa:hvr/ghc
- - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 happy-1.19.3 ghc-$GHCVER
- - export PATH=/opt/happy/1.19.3/bin:/opt/ghc/$GHCVER/bin:$PATH
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
- - type happy
- - cabal-1.18 update
- - cabal-1.18 install aeson haskell-awk --only-dependencies --enable-tests --enable-benchmarks
+# Build dependencies
+- stack --no-terminal --install-ghc test --only-dependencies
 
-# Here starts the actual work to be performed for the package under
-# test; any command which exits with a non-zero exit code causes the
-# build to fail.
 script:
- - echo $PATH
- # -v2 provides useful information for debugging
- - cabal-1.18 configure --enable-tests --enable-benchmarks -v2
-
- # this builds all libraries and executables
- # (including tests/benchmarks)
- - cabal-1.18 build
-
- - cabal-1.18 test
- - cabal-1.18 check
-
- # tests that a source-distribution can be generated
- - cabal-1.18 sdist
-
- # check that the generated source-distribution can be built & installed
- - export SRC_TGZ=$(cabal-1.18 info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   if [ -f "$SRC_TGZ" ]; then
-      tar tf "$SRC_TGZ";
-      cabal-1.18 install "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi
-
-matrix:
-  allow_failures:
-   - env: GHCVER=head
-
-# EOF
+# Build the package, its tests, and its docs and run the tests
+- stack --no-terminal test --haddock --no-haddock-deps

--- a/haskell-awk.cabal
+++ b/haskell-awk.cabal
@@ -80,33 +80,34 @@ Library
                  , stringsearch >=0.3.6.4
     Default-Language: Haskell98
 
-Test-suite reference
-  Hs-Source-Dirs:       src,tests
-  Main-Is:              RunTests.hs
-  Type:                 exitcode-stdio-1.0
-  Ghc-Options:          -Wall
-  Build-Depends:        base >=4.6.0.1 && <5
-                      , bytestring
-                      , containers
-                      , directory
-                      , doctest >=0.3.0
-                      , easy-file
-                      , exceptions >=0.1
-                      , extra
-                      , filepath
-                      , haskell-awk
-                      , haskell-src-exts >=1.14.0 && < 1.18
-                      , hint >=0.3.3.5
-                      , hspec >=0.2.0
-                      , HUnit >=1.1
-                      , mtl >=2.1.2
-                      , network >=2.3.1.0
-                      , process
-                      , stringsearch >=0.3.6.4
-                      , template-haskell
-                      , temporary >=1.0
-                      , test-framework >=0.1
-                      , test-framework-hunit >=0.2.0
-                      , time
-                      , transformers >=0.3.0.0
-  Default-Language: Haskell98
+--Test-suite reference
+--  Hs-Source-Dirs:       src,tests
+--  Main-Is:              RunTests.hs
+--  Type:                 exitcode-stdio-1.0
+--  Ghc-Options:          -Wall
+--  Build-Depends:        base >=4.6.0.1 && <5
+--                      , aeson
+--                      , bytestring
+--                      , containers
+--                      , directory
+--                      , doctest >=0.3.0
+--                      , easy-file
+--                      , exceptions >=0.1
+--                      , extra
+--                      , filepath
+--                      , haskell-awk
+--                      , haskell-src-exts >=1.14.0 && < 1.18
+--                      , hint >=0.3.3.5
+--                      , hspec >=0.2.0
+--                      , HUnit >=1.1
+--                      , mtl >=2.1.2
+--                      , network >=2.3.1.0
+--                      , process
+--                      , stringsearch >=0.3.6.4
+--                      , template-haskell
+--                      , temporary >=1.0
+--                      , test-framework >=0.1
+--                      , test-framework-hunit >=0.2.0
+--                      , time
+--                      , transformers >=0.3.0.0
+--  Default-Language: Haskell98

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-10.3
+packages:
+- .
+extra-deps:
+- haskell-src-exts-1.17.1


### PR DESCRIPTION
It is still possible to build the project using cabal, so issues like #148, #149 and #168 remain relevant. I want to track those issues so I can _eventually_ allow hawk to build with other versions of ghc and other versions of the dependencies, but for now it's already enough work just to support a single version of everything, so I'm switching travis to only build that single version for now. Once I manage to close enough issues to make hawk buildable with other versions and other build systems, I will amend the travis configuration to check those workflows too.