### PR TITLE
make sure we can build with 'cabal new-build'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ language: generic
 cache:
   directories:
   - $HOME/.stack
+  - $HOME/.cabal
 
 # Ensure necessary system libraries are present
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - cabal-install
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,26 @@ addons:
   apt:
     packages:
       - libgmp-dev
-      - cabal-install
+      # this installs an older version of cabal which doesn't support new-build
+      #- cabal-install
 
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+# Install a recent version of cabal which supports new-build
+- stack install cabal
 
 install:
-# Build dependencies
+# Build dependencies (stack)
 - stack --no-terminal --install-ghc test --only-dependencies
+# Build dependencies (cabal)
+- cabal update
+- ~/.local/bin/cabal new-build --only-dependencies
 
 script:
-# Build the package, its tests, and its docs and run the tests
+# Build the package, its tests, and its docs and run the tests (stack)
 - stack --no-terminal test --haddock --no-haddock-deps
-# Also make sure it builds with cabal
-- cabal update
-- cabal new-build
+# Build the package (cabal)
+- ~/.local/bin/cabal new-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ install:
 script:
 # Build the package, its tests, and its docs and run the tests
 - stack --no-terminal test --haddock --no-haddock-deps
+# Also make sure it builds with cabal
+- cabal update
+- cabal new-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,11 @@ install:
 # Build dependencies (stack)
 - stack --no-terminal --install-ghc test --only-dependencies
 # Build dependencies (cabal)
-- cabal update
-- ~/.local/bin/cabal new-build --only-dependencies
+- stack exec -- cabal update
+- stack exec -- cabal new-build --only-dependencies
 
 script:
 # Build the package, its tests, and its docs and run the tests (stack)
 - stack --no-terminal test --haddock --no-haddock-deps
 # Build the package (cabal)
-- ~/.local/bin/cabal new-build
+- stack exec -- cabal new-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 # Install a recent version of cabal which supports new-build
-- stack install cabal
+- stack install cabal-install
 
 install:
 # Build dependencies (stack)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - ghc
       # this installs an older version of cabal which doesn't support new-build
       #- cabal-install
 
@@ -40,11 +41,11 @@ install:
 # Build dependencies (stack)
 - stack --no-terminal --install-ghc test --only-dependencies
 # Build dependencies (cabal)
-- stack exec -- cabal update
-- stack exec -- cabal new-build --only-dependencies
+- ~/.local/bin/cabal update
+- ~/.local/bin/cabal new-build --only-dependencies
 
 script:
 # Build the package, its tests, and its docs and run the tests (stack)
 - stack --no-terminal test --haddock --no-haddock-deps
 # Build the package (cabal)
-- stack exec -- cabal new-build
+- ~/.local/bin/cabal new-build


### PR DESCRIPTION
I'm sure there's a way to configure travis to run the stack and cabal
builds in parallel instead of one after the other, but I don't feel like
learning about the travis configuration format right now.