### PR TITLE
fix #180

### DIFF
--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -442,13 +442,13 @@ consumeLast o optionConsumer = do
 
 -- | For use with mutually-exclusive flags.
 consumeExclusive :: (Option o, Functor m, Monad m)
-                 => [(o, a)] -> a -> OptionParserT o m a
+                 => [(o, a)] -> OptionParserT o m (Maybe a)
 consumeExclusive = consumeExclusiveWith longName
 
 -- | A version of `consumeExclusive` which doesn't use the Option typeclass.
 --
 -- >>> let tp = const flag
--- >>> let consume = consumeExclusiveWith id [("cowbell",0),("guitar",1),("saxophone",2)] (-1) :: OptionParser String Int
+-- >>> let consume = fromMaybe (-1) <$> consumeExclusiveWith id [("cowbell",0),("guitar",1),("saxophone",2)] :: OptionParser String Int
 --
 -- >>> testP ["-s"] tp consume
 -- 2
@@ -461,13 +461,13 @@ consumeExclusive = consumeExclusiveWith longName
 -- *** Exception: ExitFailure 1
 consumeExclusiveWith :: (Eq o, Functor m, Monad m)
                      => (o -> String)
-                     -> [(o, a)] -> a -> OptionParserT o m a
-consumeExclusiveWith longName' assoc defaultValue = do
+                     -> [(o, a)] -> OptionParserT o m (Maybe a)
+consumeExclusiveWith longName' assoc = do
     oss <- forM (map fst assoc) $ \o ->
       map (const o) <$> consumeAll o flagConsumer
     case concat oss of
-      []  -> return defaultValue
-      [o] -> return $ fromMaybe defaultValue $ lookup o assoc
+      []  -> return Nothing
+      [o] -> return $ lookup o assoc
       os  -> fail msg
         where
           n = length os

--- a/src/System/Console/Hawk/Args/Option.hs
+++ b/src/System/Console/Hawk/Args/Option.hs
@@ -48,8 +48,8 @@ parseDelimiter s = pack $ case reads (printf "\"%s\"" s) of
     _          -> s
 
 -- | Almost like a string, except escape sequences are interpreted.
-consumeDelimiter :: (Functor m, Monad m) => OptionConsumer m ByteString
-consumeDelimiter = fmap parseDelimiter . consumeOptional "" consumeString
+delimiterConsumer :: (Functor m, Monad m) => OptionConsumerT m ByteString
+delimiterConsumer = parseDelimiter <$> optionalConsumer "" stringConsumer
 
 instance Option HawkOption where
   shortName Apply                 = 'a'

--- a/src/System/Console/Hawk/Args/Option.hs
+++ b/src/System/Console/Hawk/Args/Option.hs
@@ -27,7 +27,7 @@ options = enumFrom minBound
 
 
 delimiter :: OptionType
-delimiter = nullable (Setting "delim")
+delimiter = optional (Setting "delim")
 
 -- | Interpret escape sequences, but don't worry if they're invalid.
 -- 
@@ -49,7 +49,7 @@ parseDelimiter s = pack $ case reads (printf "\"%s\"" s) of
 
 -- | Almost like a string, except escape sequences are interpreted.
 consumeDelimiter :: (Functor m, Monad m) => OptionConsumer m ByteString
-consumeDelimiter = fmap parseDelimiter . consumeNullable "" consumeString
+consumeDelimiter = fmap parseDelimiter . consumeOptional "" consumeString
 
 instance Option HawkOption where
   shortName Apply                 = 'a'

--- a/src/System/Console/Hawk/Args/Option.hs
+++ b/src/System/Console/Hawk/Args/Option.hs
@@ -48,8 +48,8 @@ parseDelimiter s = pack $ case reads (printf "\"%s\"" s) of
     _          -> s
 
 -- | Almost like a string, except escape sequences are interpreted.
-delimiterConsumer :: (Functor m, Monad m) => OptionConsumerT m ByteString
-delimiterConsumer = parseDelimiter <$> optionalConsumer "" stringConsumer
+delimiterConsumer :: (Functor m, Monad m) => OptionConsumerT m (Maybe ByteString)
+delimiterConsumer = fmap parseDelimiter <$> optionalConsumer stringConsumer
 
 instance Option HawkOption where
   shortName Apply                 = 'a'

--- a/src/System/Console/Hawk/Args/Parse.hs
+++ b/src/System/Console/Hawk/Args/Parse.hs
@@ -219,7 +219,7 @@ parseArgs args = runOptionParserT options parser args
   where
     parser = do
         lift $ return ()  -- silence a warning
-        cmd <- consumeExclusive assoc eval
+        cmd <- fromMaybe eval <$> consumeExclusive assoc
         c <- commonSeparators
         cmd c
     assoc = [ (Option.Help,    help)


### PR DESCRIPTION
The option-consuming functions now return a Maybe instead of taking a default value.

Also, OptionConsumer is now a newtype instead of a type synonym, so we can easily fmap the resulting Maybe into another shape if needed. I have renamed the corresponding functions (e.g. `consumeString` to `stringConsumer`) in order to distinguish them from the option-consuming functions (e.g. `consumeAll` and `consumeLast`).