### PR TITLE
update stack.yaml to lts-12.26

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.0
+resolver: lts-12.26
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
hawk build fine with Stack LTS < 13

(With LTS 13 (ghc-8.6) it hits MonadFail issues)