### PR TITLE
store the oldest supported lts in a separate file, fixes #218

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ env:
 # versions provided by that new lts!
 - BUILD=stack RESOLVER="lts-8.0"
 
-- BUILD=stack RESOLVER="lts-12.19"
-- BUILD=cabal RESOLVER="lts-12.19"
+- BUILD=stack RESOLVER="lts-12.26"
+- BUILD=cabal RESOLVER="lts-12.26"
 
 before_install:
 # Download and unpack the stack executable

--- a/bump-lower-bounds.vim
+++ b/bump-lower-bounds.vim
@@ -1,6 +1,6 @@
-"for future reference, here is a vim macro which, when the cursos is on a line like
+"for future reference, here is a vim macro which, when the cursor is on a line like
 "
 "  - haskell-src-exts >= 1.0
 "
 "will update the lower bound to match the version used by the current lts.
-0dwdwEld$A '^isa€kbtack ls dependencies --test | grep '^V:!bashWi>= 0i      - j
+0dwdwEld$A '^istack --stack-yaml=stack-oldest-supported-lts.yaml ls dependencies --test | grep '^V:!bashWi>= 0i      - j

--- a/stack-oldest-supported-lts.yaml
+++ b/stack-oldest-supported-lts.yaml
@@ -1,0 +1,4 @@
+resolver: lts-8.0
+packages:
+- .
+extra-deps: []


### PR DESCRIPTION
this way, bumping the version bounds will be less error-prone: instead
of changing stack.yaml's lts to the lowest-supported lts, running
bump-lower-bounds.vim to bump the lower bounds, and then hopefully not
forgetting to revert stack.yaml's lts to the highest-supported lts, I
can bump stack-oldest-supported-lts.yaml's lts and then run
bump-lower-bounds.vim, with no extra easy-to-forget step.
