### PR TITLE
MonadFail instances to allow building also with base >= 4.13

### DIFF
--- a/haskell-awk.cabal
+++ b/haskell-awk.cabal
@@ -38,7 +38,7 @@ library
       runtime
   ghc-options: -Wall
   build-depends:
-      base >=4.9.1.0 && <4.12.0.0
+      base >=4.9.1.0 && <5
     , bytestring >=0.10.8.1
     , containers >=0.5.7.1
     , list-t >=1
@@ -87,7 +87,7 @@ executable hawk
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.9.1.0 && <4.12.0.0
+      base >=4.9.1.0 && <5
     , bytestring >=0.10.8.1
     , containers >=0.5.7.1
     , directory >=1.3.0.0

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,7 @@ extra-source-files:
 
 ghc-options: -Wall
 dependencies:
-  - base >= 4.9.1.0 && < 4.12.0.0
+  - base >= 4.9.1.0 && < 5
   - bytestring >= 0.10.8.1
   - containers >= 0.5.7.1
   - stringsearch >= 0.3.6.6

--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -4,6 +4,7 @@
 module Control.Monad.Trans.OptionParser where
 
 import Control.Monad
+import qualified Control.Monad.Fail as Fail
 import "mtl" Control.Monad.Identity
 import "mtl" Control.Monad.Trans
 import Control.Monad.Trans.State
@@ -73,6 +74,8 @@ instance Monad m => Monad (OptionParserT o m) where
   OptionParserT mx >>= f = OptionParserT (mx >>= f')
     where
       f' = unOptionParserT . f
+
+instance Monad m => Fail.MonadFail (OptionParserT o m) where
   fail s = OptionParserT (fail s)
 
 instance MonadTrans (OptionParserT o) where

--- a/src/Control/Monad/Trans/State/Persistent.hs
+++ b/src/Control/Monad/Trans/State/Persistent.hs
@@ -4,6 +4,7 @@ module Control.Monad.Trans.State.Persistent where
 
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Fail
 import Control.Monad.IO.Class
 import "mtl" Control.Monad.Trans
 import Control.Monad.Trans.Maybe
@@ -67,7 +68,7 @@ withPersistentState f default_s sx = do
 -- 
 -- 
 -- >>> removeFile f
-withPersistentStateT :: forall m s a. (Functor m, MonadIO m, Read s, Show s, Eq s)
+withPersistentStateT :: forall m s a. (Functor m, MonadIO m, MonadFail m, Read s, Show s, Eq s)
                      => FilePath -> s -> StateT s m a -> m a
 withPersistentStateT f default_s sx = do
     Just s <- runMaybeT (get_s <|> get_default_s)

--- a/src/Control/Monad/Trans/Uncertain.hs
+++ b/src/Control/Monad/Trans/Uncertain.hs
@@ -2,6 +2,7 @@
 -- | A computation which may raise warnings or fail in error.
 module Control.Monad.Trans.Uncertain where
 
+import qualified Control.Monad.Fail as Fail
 import "mtl" Control.Monad.Trans
 import "mtl" Control.Monad.Identity
 import "transformers" Control.Monad.Trans.Except
@@ -31,6 +32,8 @@ instance Monad m => Monad (UncertainT m) where
   UncertainT mx >>= f = UncertainT (mx >>= f')
     where
       f' = unUncertainT . f
+
+instance Monad m => Fail.MonadFail (UncertainT m) where
   fail s = UncertainT (throwE s)
 
 instance MonadTrans UncertainT where


### PR DESCRIPTION
I tested this allows building hawk from lts8 to lts15 (and nightly).