### PR TITLE
delete the last failing System.Console.Hawk.Test, fixes #201

### DIFF
--- a/tests/System/Console/Hawk/Test.hs
+++ b/tests/System/Console/Hawk/Test.hs
@@ -29,8 +29,6 @@ run = withContextHSpec $ \itEval itApply itMap ->
         describe "Hawk" $ do
           itEval "1" `into` "1\n"
           itEval "1+1" `into` "2\n"
-          -- TODO: why is this test failing?
-          --itEval "[]" `into` ""
           itEval "[1]" `into` "1\n"
           itEval "[1,2]" `into` "1\n2\n"
           itEval "(1,2)" `into` "1\n2\n"


### PR DESCRIPTION
The failing test was that [] should evaluate to "", but instead has an
ambiguous type. Well, I agree that [] has an ambiguous type. Maybe older
versions of ghc were defaulting it to type [()]; but if newer versions
of ghc aren't, no big deal, I don't think this is a feature worth
keeping.