### PR TITLE
reduce compiler warnings

### DIFF
--- a/src/Control/Monad/Trans/OptionParser.hs
+++ b/src/Control/Monad/Trans/OptionParser.hs
@@ -7,7 +7,11 @@ import Prelude hiding (fail)
 
 import Control.Monad hiding (fail)
 #if MIN_VERSION_base(4,12,0)
-import Control.Monad.Fail (MonadFail, fail)
+import Control.Monad.Fail (
+#if !MIN_VERSION_base(4,13,0)
+  MonadFail,
+#endif
+  fail)
 #else
 import Prelude (fail)
 #endif

--- a/src/Control/Monad/Trans/State/Persistent.hs
+++ b/src/Control/Monad/Trans/State/Persistent.hs
@@ -4,7 +4,7 @@ module Control.Monad.Trans.State.Persistent where
 
 import Control.Applicative
 import Control.Monad
-#if MIN_VERSION_base(4,12,0)
+#if MIN_VERSION_base(4,12,0) && !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
 #endif
 import Control.Monad.IO.Class

--- a/src/Control/Monad/Trans/Uncertain.hs
+++ b/src/Control/Monad/Trans/Uncertain.hs
@@ -5,7 +5,11 @@ module Control.Monad.Trans.Uncertain where
 import Prelude hiding (fail)
 
 #if MIN_VERSION_base(4,12,0)
-import Control.Monad.Fail (MonadFail, fail)
+import Control.Monad.Fail (
+#if !MIN_VERSION_base(4,13,0)
+  MonadFail,
+#endif
+  fail)
 #else
 import Prelude (fail)
 #endif

--- a/src/Language/Haskell/Exts/Location.hs
+++ b/src/Language/Haskell/Exts/Location.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Easier access to haskell-src-exts's SrcLoc values.
 module Language.Haskell.Exts.Location where
 
@@ -14,11 +16,23 @@ import Language.Haskell.Exts.Syntax
 -- 
 -- The location only indicates the beginning of a range, because that's what
 -- haskell-src-exts provides.
-type Located a = Writer (Option (Min SrcLoc)) a
+type Located a = Writer (
+#if MIN_VERSION_base(4,11,0)
+  Maybe
+#else
+  Option
+#endif
+    (Min SrcLoc)) a
 
 located :: SrcLoc -> Located ()
-located srcLoc | srcLoc == noLoc = tell $ Option $ Nothing
-               | otherwise       = tell $ Option $ Just $ Min srcLoc
+located srcLoc =
+  tell $
+#if !MIN_VERSION_base(4,11,0)
+  Option $
+#endif
+  if srcLoc == noLoc
+  then Nothing
+  else Just $ Min srcLoc
 
 annotated :: (Annotated ast, SrcInfo si) => ast si -> Located (ast si)
 annotated x = do
@@ -28,4 +42,8 @@ annotated x = do
 runLocated :: Located a -> (a, Maybe SrcLoc)
 runLocated = go . runWriter
   where
-    go (x, p) = (x, fmap getMin $ getOption $ p)
+    go (x, p) = (x, fmap getMin $
+#if !MIN_VERSION_base(4,11,0)
+                  getOption
+#endif
+                  p)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.5
+resolver: lts-17.15
 packages:
 - .
 extra-deps: []

--- a/tests/System/Console/Hawk/TestUtils.hs
+++ b/tests/System/Console/Hawk/TestUtils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 --   Copyright 2013 Mario Pastorelli (pastorelli.mario@gmail.com) Samuel Gélineau (gelisam@gmail.com)
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +16,10 @@
 
 module System.Console.Hawk.TestUtils where
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
   ( (<$>) )
+#endif
 import Control.Exception
   ( bracket_ )
 import Data.List


### PR DESCRIPTION
This silences a number of compile time warnings:
- MonadFail import on ghc-8.8+
- <$> for base >= 4.8
- Semigroup Option deprecation in ghc-9.0

Also bumps stack resolver to latest lts-17.15