### PR TITLE
test with lts16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       name: Setup Stack
       with:
         enable-stack: true
-        stack-setup-ghc: true
+        stack-setup-ghc: false
         stack-no-global: true
 
     # For some reason, installing happy from lts-9.0 fails unless some other

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.5
+resolver: lts-16.31
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
I am getting weird `stack test` errors locally with lts16 and earlier:
```
Finished in 0.0004 seconds
14 examples, 0 failures

Hawk
error: Won't compile:
	<interactive>:1:1: error:
    attempting to use module ‘main:M1338261393241126579867105’ (/var/home/petersen/tmp/hint-c07f4e051b9e8d8f/M1338261393241126579867105.hs) which is not loaded
error: Won't compile:
	<interactive>:1:1: error:
    attempting to use module ‘main:M2120538248708628250867105’ (/var/home/petersen/tmp/hint-da65bcb72c3b99cd/M2120538248708628250867105.hs) which is not loaded
: 
:
```