### PR TITLE
stack: bump oldest to lts10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,21 +58,7 @@ jobs:
         stack-setup-ghc: true
         stack-no-global: true
 
-    # For some reason, installing happy from lts-9.0 fails unless some other
-    # version of happy is already in the PATH. So let's install a version of
-    # happy from an lts which does not have this problem.
-    - name: Install happy
-      if: matrix.stack_yaml == 'oldest-supported-lts.yaml'
-      run: |
-        stack --stack-yaml=stack.yaml install happy
-
-    - name: Build with happy hack
-      if: matrix.stack_yaml == 'oldest-supported-lts.yaml'
-      run: |
-        PATH="$HOME/.local/bin:$PATH" stack --stack-yaml=${{ matrix.stack_yaml }} install --test --bench --no-run-tests --no-run-benchmarks
-
     - name: Build
-      if: matrix.stack_yaml == 'stack.yaml'
       run: |
         stack --stack-yaml=${{ matrix.stack_yaml }} install --test --bench --no-run-tests --no-run-benchmarks
 

--- a/haskell-awk.cabal
+++ b/haskell-awk.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7517e27fc1a323df0f63f63937abf935ca1ecdd5376effed8078a1c1dd86928a
+-- hash: f55620402d4a8fffd583a55822ca5cef69e307d45aa1875dd37dbac5cc9a4720
 
 name:           haskell-awk
 version:        1.2.0.1
@@ -46,8 +46,8 @@ source-repository head
 
 custom-setup
   setup-depends:
-      Cabal >=1.24.2.0
-    , base >=4.9 && <5
+      Cabal >=2.0.1.1
+    , base >=4.10.1.0 && <5
     , cabal-doctest >=1.0.4
 
 library
@@ -64,16 +64,16 @@ library
       runtime
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <5
-    , bytestring >=0.10.8.1
-    , containers >=0.5.7.1
-    , ghc >=8.0.2
-    , list-t >=1
+      base >=4.10.1.0 && <5
+    , bytestring >=0.10.8.2
+    , containers >=0.5.10.2
+    , ghc >=8.2.2
+    , list-t >=1.0.0.1
     , stringsearch >=0.3.6.6
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010
 
 executable hawk
   main-is: Main.hs
@@ -117,26 +117,26 @@ executable hawk
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <5
-    , bytestring >=0.10.8.1
-    , containers >=0.5.7.1
-    , directory >=1.3.0.0
-    , extra >=1.5.3
-    , filelock >=0.1.0.1
-    , filepath >=1.4.1.1
-    , ghc >=8.0.2
+      base >=4.10.1.0 && <5
+    , bytestring >=0.10.8.2
+    , containers >=0.5.10.2
+    , directory >=1.3.0.2
+    , extra >=1.6.2
+    , filelock >=0.1.1.2
+    , filepath >=1.4.1.2
+    , ghc >=8.2.2
     , haskell-awk
-    , haskell-src-exts >=1.18.2
+    , haskell-src-exts >=1.19.1
     , hint >=0.7.0
-    , list-t >=1
+    , list-t >=1.0.0.1
     , mtl >=2.2.1
-    , process >=1.4.3.0
-    , template-haskell >=2.11.1.0
+    , process >=1.6.1.0
+    , template-haskell >=2.12.0.0
     , transformers >=0.5.2.0
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010
 
 test-suite reference
   type: exitcode-stdio-1.0
@@ -189,34 +189,34 @@ test-suite reference
       tests
   ghc-options: -Wall
   build-depends:
-      HUnit >=1.5.0.0
-    , aeson >=1.1.2.0
-    , attoparsec >=0.13.1.0
-    , base >=4.9 && <5
-    , bytestring >=0.10.8.1
-    , containers >=0.5.7.1
-    , directory >=1.3.0.0
-    , doctest >=0.11.4
+      HUnit >=1.6.0.0
+    , aeson >=1.2.3.0
+    , attoparsec >=0.13.2.0
+    , base >=4.10.1.0 && <5
+    , bytestring >=0.10.8.2
+    , containers >=0.5.10.2
+    , directory >=1.3.0.2
+    , doctest >=0.13.0
     , easy-file >=0.2.1
     , exceptions >=0.8.3
-    , extra >=1.5.3
-    , filelock >=0.1.0.1
-    , filepath >=1.4.1.1
-    , ghc >=8.0.2
+    , extra >=1.6.2
+    , filelock >=0.1.1.2
+    , filepath >=1.4.1.2
+    , ghc >=8.2.2
     , haskell-awk
-    , haskell-src-exts >=1.18.2
+    , haskell-src-exts >=1.19.1
     , hint >=0.7.0
     , hspec >=2.4.4
-    , list-t >=1
+    , list-t >=1.0.0.1
     , mtl >=2.2.1
-    , process >=1.4.3.0
-    , template-haskell >=2.11.1.0
-    , temporary >=1.2.1
+    , process >=1.6.1.0
+    , template-haskell >=2.12.0.0
+    , temporary >=1.2.1.1
     , test-framework >=0.8.1.1
     , test-framework-hunit >=0.3.0.2
-    , time >=1.6.0.1
+    , time >=1.8.0.2
     , transformers >=0.5.2.0
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010

--- a/oldest-supported-lts.yaml
+++ b/oldest-supported-lts.yaml
@@ -1,5 +1,1 @@
-resolver: lts-9.0
-packages:
-- .
-extra-deps:
-  - cabal-doctest-1.0.4
+resolver: lts-10.0

--- a/package.yaml
+++ b/package.yaml
@@ -19,11 +19,11 @@ extra-source-files:
 
 ghc-options: -Wall
 dependencies:
-  - base >= 4.9 && < 5
-  - bytestring >= 0.10.8.1
-  - containers >= 0.5.7.1
-  - ghc >= 8.0.2
-  - list-t >= 1
+  - base >= 4.10.1.0 && < 5
+  - bytestring >= 0.10.8.2
+  - containers >= 0.5.10.2
+  - ghc >= 8.2.2
+  - list-t >= 1.0.0.1
 
 # Windows is not currently supported, see issue #248
 when:
@@ -35,8 +35,8 @@ when:
 
 custom-setup:
   dependencies:
-    - base >= 4.9 && < 5
-    - Cabal >= 1.24.2.0
+    - base >= 4.10.1.0 && < 5
+    - Cabal >= 2.0.1.1
     - cabal-doctest >= 1.0.4
 
 library:
@@ -48,16 +48,16 @@ executables:
   hawk:
     main:        Main.hs
     dependencies:
-      - directory >= 1.3.0.0
-      - extra >= 1.5.3
-      - filelock >= 0.1.0.1
-      - filepath >= 1.4.1.1
+      - directory >= 1.3.0.2
+      - extra >= 1.6.2
+      - filelock >= 0.1.1.2
+      - filepath >= 1.4.1.2
       - haskell-awk
-      - haskell-src-exts >= 1.18.2
+      - haskell-src-exts >= 1.19.1
       - hint >= 0.7.0
       - mtl >= 2.2.1
-      - process >= 1.4.3.0
-      - template-haskell >= 2.11.1.0
+      - process >= 1.6.1.0
+      - template-haskell >= 2.12.0.0
       - transformers >= 0.5.2.0
     source-dirs: src
 
@@ -68,25 +68,25 @@ tests:
       - tests
     main: RunTests.hs
     dependencies:
-      - aeson >= 1.1.2.0
-      - attoparsec >= 0.13.1.0
-      - directory >= 1.3.0.0
-      - doctest >= 0.11.4
+      - aeson >= 1.2.3.0
+      - attoparsec >= 0.13.2.0
+      - directory >= 1.3.0.2
+      - doctest >= 0.13.0
       - easy-file >= 0.2.1
       - exceptions >= 0.8.3
-      - extra >= 1.5.3
-      - filelock >= 0.1.0.1
-      - filepath >= 1.4.1.1
+      - extra >= 1.6.2
+      - filelock >= 0.1.1.2
+      - filepath >= 1.4.1.2
       - haskell-awk
-      - haskell-src-exts >= 1.18.2
+      - haskell-src-exts >= 1.19.1
       - hint >= 0.7.0
       - hspec >= 2.4.4
-      - HUnit >= 1.5.0.0
+      - HUnit >= 1.6.0.0
       - mtl >= 2.2.1
-      - process >= 1.4.3.0
-      - template-haskell >= 2.11.1.0
-      - temporary >= 1.2.1
+      - process >= 1.6.1.0
+      - template-haskell >= 2.12.0.0
+      - temporary >= 1.2.1.1
       - test-framework >= 0.8.1.1
       - test-framework-hunit >= 0.3.0.2
-      - time >= 1.6.0.1
+      - time >= 1.8.0.2
       - transformers >= 0.5.2.0


### PR DESCRIPTION
Let's not sweat it/worry if lts9 is failing.

(Btw If it were me I would just go with the final minor release:
I don't think users are that interested in building with lts-x.0.)

pps I had pondered even to bump to lts11...