### PR TITLE
enable the 'Run workflow' button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           .stack-work
         key: ${{ runner.os }}-stack-${{ hashFiles(matrix.stack_yaml) }}-6
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-stack
       name: Setup Stack
       with:
@@ -103,7 +103,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Cabal
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,12 @@ jobs:
           # Check that our upper bounds are correct by building with the latest
           # version of everything. We use cabal because it uses the latest
           # versions of our dependencies allowed by our upper bounds.
+          #
+          # TODO: revert to "ghc: latest" once the latest version of ghc is
+          # supported, so we can detect when an even-more-recent version of ghc
+          # is released and breaks hawk.
           - name: newest
-            ghc: latest
+            ghc: 8.10.4
             os: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
   # Build once a month, to detect missing upper bounds.
   schedule:
     - cron: '0 0 1 * *'
+  
+  workflow_dispatch:
 
 jobs:
   stack:

--- a/.github/workflows/installation-methods.yml
+++ b/.github/workflows/installation-methods.yml
@@ -12,6 +12,8 @@ on:
   #pull_request:
   #  types: [opened, synchronize]
 
+  workflow_dispatch:
+
 jobs:
   # the stack installation method is already covered by the regular CI tests
   installation-methods:

--- a/.github/workflows/installation-methods.yml
+++ b/.github/workflows/installation-methods.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       if: matrix.method == 'v1-install' || matrix.method == 'cabal-sandbox'
       id: setup-haskell-cabal_1
       name: Setup Cabal
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: 3.2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       if: matrix.method != 'v1-install' && matrix.method != 'cabal-sandbox'
       id: setup-haskell-cabal_2
       name: Setup Cabal

--- a/haskell-awk.cabal
+++ b/haskell-awk.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7517e27fc1a323df0f63f63937abf935ca1ecdd5376effed8078a1c1dd86928a
+-- hash: 186d50c3926564fc359e64329c322981465bb7d43c4c1c3fb8f2edfa8c60a5f0
 
 name:           haskell-awk
 version:        1.2.0.1
@@ -18,6 +18,9 @@ maintainer:     Samuel Gélineau <gelisam@gmail.com>, Jens Petersen <juhpetersen
 license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Custom
+tested-with:
+    GHC==8.0.2
+  , GHC==8.10.4
 extra-source-files:
     README.md
     CHANGELOG.md
@@ -70,10 +73,10 @@ library
     , ghc >=8.0.2
     , list-t >=1
     , stringsearch >=0.3.6.6
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010
 
 executable hawk
   main-is: Main.hs
@@ -133,10 +136,10 @@ executable hawk
     , process >=1.4.3.0
     , template-haskell >=2.11.1.0
     , transformers >=0.5.2.0
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010
 
 test-suite reference
   type: exitcode-stdio-1.0
@@ -216,7 +219,7 @@ test-suite reference
     , test-framework-hunit >=0.3.0.2
     , time >=1.6.0.1
     , transformers >=0.5.2.0
+  default-language: Haskell2010
   if os(windows)
     build-depends:
         base <0
-  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -90,3 +90,7 @@ tests:
       - test-framework-hunit >= 0.3.0.2
       - time >= 1.6.0.1
       - transformers >= 0.5.2.0
+
+tested-with:
+  - GHC==8.0.2
+  - GHC==8.10.4


### PR DESCRIPTION
CI was scheduled to run automatically every month, so that if a new version of GHC or of one of hawk's dependencies gets released and causes hawk to no longer compile, I get notified and can quickly add an upper bound.

But GitHub automatically disables my monthly CI runs after a couple of months, so the inevitable happened: hawk no longer compiles with the latest version of everything (#275).

Let's enable the `Run workflow` button so that I can at least _manually_ run CI, even if I can't run it automatically every month.